### PR TITLE
Results of HVA

### DIFF
--- a/DixHVA.m
+++ b/DixHVA.m
@@ -42,7 +42,7 @@ end
     % Force Columns
     Vint = Vint(:); Hint = Hint(:);
     % Physically Constrained Solution
-    iceIx = find(Vint<0.1689);
+    iceIx = find(Vint<0.1689 | Vint > 0.25);
     Vint(iceIx) = [];
     Hint(iceIx) = [];
     

--- a/SWEDISH.m
+++ b/SWEDISH.m
@@ -78,15 +78,16 @@ isParallel = 1;
 
 % Read Data
 isReadSensorsSoftware = 1;     % Read Multiplexed Data
+isLoadTimeHorizons = 0;        % Load Previously Picked Time Horizons
+
+% Export Data
+isWriteTimeHorizons = 0;
 
 % Process Data
 isTrimTWT = 0;          % Truncate Recorded Data for Near-Surface Analysis
 isKill = 0;             % Kill Unanted Channels
 isFXdecon = 1;          % Fx-Predicitive Deconvolution
 isSWEDISH = 1;          % Perform Surface Velocity Analysis
-
-% Export Data
-isWrite = 0;
 
 %% Control Parallelization
 if isParallel
@@ -201,13 +202,13 @@ if isReadSensorsSoftware
         dupIx = find(~(diff(trhd{ii}(23,:)))); % Find Skipped Traces
         
         for jj = dupIx
-            trhd{ii}(1,jj:end) = trhd{ii}(1,jj:end) - 1; % Configure Trace Indicies
-            trhd{ii}(2,jj:end) = trhd{ii}(2,jj:end) - dx;% Configure Distance
+            trhd{ii}(1,jj:end) = trhd{ii}(1,jj:end) - 1; % ReConfigure Trace Indicies
+%             trhd{ii}(2,jj:end) = trhd{ii}(2,jj:end) - dx;% ReConfigure Distance
         end
         
         trhd{ii}(:,dupIx) = []; % Remove Skipped Traces from Trace Header
         Rad{ii}(:,dupIx) = []; % Remove Skipped Traces from Multiplexed Data
-        xArray = trhd{ii}(2,:); % Define Configured Distance as xArray
+        xArray = trhd{ii}(2,:); % Define ReConfigured Distance as xArray
         end
         % Gain Far Channels for Cable Attenuation
         if f0 == 500
@@ -317,8 +318,12 @@ if isReadSensorsSoftware
 end
 %% Concatenate Files
     % Grab Early Time Data For AirWave Cross Correlation Alignment
-    xcorrWindow = [175, 250, 85, 140, 230, 75, 100, 180, 25;...
-                    200, 300, 150, 160, 260, 115, 150, 220, 75] + padding;
+    % 2016
+        xcorrWindow = [30, 105, 180, 0, 80, 145, -20, 45, 130;...
+                    60, 150, 210, 40, 110, 175, 5, 80, 160] + padding;
+    % 2017
+%     xcorrWindow = [175, 250, 85, 140, 230, 75, 100, 180, 25;...
+%                     200, 300, 150, 160, 260, 115, 150, 220, 75] + padding;
     if isKill
         xcorrWindow(:,killChan) = [];
     end
@@ -336,11 +341,26 @@ end
         end
          Radar = catRadar; clear catRadar;
     end
+    
+%% Branch Processing for Direct and Reflected Arrivals
+directRadar = Radar;
+
+%% Median Background Subtraction Filter for Reflection Analysis
+    medR = 1000; % Rank of Median Subtraction Window: W = 2R+1
+    for ii = 1:nFiles
+        parfor (jj = chan, nWorkers)
+%         for jj = chan;
+            Radar{jj,ii} = movingMedianSubtraction(Radar{jj,ii},medR);
+%             pickRadar{jj,ii} = pickRadar{jj,ii}-median(pickRadar{jj,ii},2)...
+%                 *ones(1,size(pickRadar{jj,ii},2));
+        end
+    end
+    
 %% FX Predicive Deconvolution
 if isFXdecon
     fprintf('Begin FX-Predictive Deconvolution \n')
     tic
-    saveRadar = Radar;
+    
     % Select Temporal or Spatial Deconvolution Gates: 1 on; 0 off;
     isTemporalFXdecon = 1;
     isSpatialFXdecon = 0;
@@ -354,50 +374,68 @@ end
 
 %% Snow Water Equivalent and Density for Ice Sheet Height
 if isSWEDISH
+    if isLoadTimeHorizons
+        TimeHorizonFilename = '';
+        load(TimeHorizonFilename);
+        % Determine Number of Direct Wave Horizons
+        nDirectHorizon = size(DirectFBpick,2);
+        % Determine Number of Reflection Horizons
+        nReflectionHorizon = size(ReflectionFBpick,2);
+    else
     %% Semi-Automatic Radar Wave Picking
     fprintf('Begin PolarPicker \n')
     display(' ')
     tic
-    
-    pickRadar = Radar;
 
     % AGC Gain for PolarPicker 
     for ii = 1:nFiles
         parfor (jj = chan, nWorkers)
-            pickRadar{jj,ii} = AGCgain(pickRadar{jj,ii},50,2);
+            directRadar{jj,ii} = AGCgain(directRadar{jj,ii},50,2);
         end
     end
     
     % Pick Direct Wave Arrival
     display('Pick Direct Wave')
     display(' ')
-%     display('If Multiple Horizons are Chosen, Initialize with Air Wave')
-%     display(' ')
-    [~, DirectFBpick] = polarPicker(pickRadar);
+    display('Initial Horizon must be the Air Wave!')
+    display(' ')
+    [~, DirectFBpick] = polarPickerT8(directRadar);
     
-    pickRadar = Radar;
+    reflectRadar = Radar;
     
-    % Median Subtraction Filter For Reflection Analysis
+        % AGC Gain for PolarPicker 
     for ii = 1:nFiles
         parfor (jj = chan, nWorkers)
-            pickRadar{jj,ii} = pickRadar{jj,ii}-median(pickRadar{jj,ii},2)...
-                *ones(1,size(pickRadar{jj,ii},2));
+            reflectRadar{jj,ii} = AGCgain(reflectRadar{jj,ii},250,2);
         end
     end
-
-    % AGC Gain for PolarPicker 
-    for ii = 1:nFiles
-        parfor (jj = chan, nWorkers)
-            pickRadar{jj,ii} = AGCgain(pickRadar{jj,ii},350,2);
+    
+    % Plot Common-offset gathers
+    isPlotOffsetGathers = 1;
+    if isPlotOffsetGathers
+        for ii = 1:nFiles
+            for jj = chan
+                figure(chan(jj)+(ii-1).*length(chan));...
+                    imagesc(reflectRadar{jj,ii});colormap(LateNite);
+            end
         end
+        
+        % Pause to Examine Common-offset Gathers
+        display('Review the Common-Offet Gathers')
+        display('Press F5 to Continue')
+        display(' ')
+        keyboard
     end
     
     % Pick Primary Reflection Arrival
     display('Pick Primary Reflection')
     display(' ')
-    [~, ReflectionFBpick] = polarPicker(pickRadar);
+    display('Reflection Horizons Must be Picked Sequenctially in Time!')
+    display(' ')
+    [~, ReflectionFBpick] = polarPickerT8(reflectRadar);
     
-    clear pickRadar
+    clear reflectRadar
+    
     % Determine Number of Direct Wave Horizons
     nDirectHorizon = size(DirectFBpick,2);
     % Determine Number of Reflection Horizons
@@ -415,92 +453,22 @@ if isSWEDISH
             end
         end
     end
+    
+    if isWriteTimeHorizons
+        save('6-2-16-Core7-Spur-W-TimeHorizon.mat','DirectFBpick','ReflectionFBpick','-v7.3');
+    end
 
     fprintf('PolarPicker Done \n')
     toc
     display(' ')
-        
+    end
 %% Perform Horizon Velocity Analysis for Estimates of Density, Depth, & SWE
     fprintf('Begin Horizon Velocity Analysis \n')
     display(' ')
     tic
-  
-    % Determine Maximum File Size
-    nTrace = zeros(1,nFiles);
-    for ii = 1:nFiles
-        nTrace(ii) = size(Radar{1,ii},2);
-    end
-    % Maxiumum Traces to Loop Over
-    nTrace = max(nTrace);
-        
-    % Allocate Memory
-    GatherReflectionPicks = cell(nReflectionHorizon,nFiles);
-    GatherDirectPicks = cell(nDirectHorizon,nFiles);
-    
-    % Allocate Direct Wave LMO Velocity Boothstrapping    
-    xVdir = cell(nDirectHorizon,nTrace,nFiles);xToDir = cell(nDirectHorizon,nTrace,nFiles);
-    VoDir = cell(nDirectHorizon,nTrace,nFiles);VoVarDir = cell(nDirectHorizon,nTrace,nFiles);
-    toDir = cell(nDirectHorizon,nTrace,nFiles);toVarDir = cell(nDirectHorizon,nTrace,nFiles);
-    DirVelocity = cell(nDirectHorizon,nFiles);RhoDir = cell(nDirectHorizon,nTrace,nFiles);
-    xRhoDir = cell(nDirectHorizon,nTrace,nFiles);DirDensity = cell(nDirectHorizon,nFiles);
-    xDepthDir = cell(nDirectHorizon,nTrace,nFiles);DepthDir  = cell(nDirectHorizon,nTrace,nFiles);
-    DepthVarDir = cell(nDirectHorizon,nTrace,nFiles);RhoDirVar  = cell(nDirectHorizon,nTrace,nFiles);
-    CovDepthRhoDir = cell(nDirectHorizon,nTrace,nFiles);
-    deltaT = cell(nFiles,nTrace);ResGatherDirPicks = cell(nDirectHorizon,nTrace,nFiles);
-    AirTo = cell(nFiles,nTrace); xAirTo = cell(nFiles,nTrace);
-    
-    % Allocate Direct Wave Snow Analysis
-    DirectTo = cell(nDirectHorizon,nFiles);DirectToVar = cell(nDirectHorizon,nFiles);
-    DirectVelocity = cell(nDirectHorizon,nFiles); DirectVelocityVar = cell(nDirectHorizon,nFiles);
-    DirectDepth = cell(nDirectHorizon,nFiles); DirectDepthVar = cell(nDirectHorizon,nFiles);
-    DirectDensity = cell(nDirectHorizon,nFiles); DirectDensityVar = cell(nDirectHorizon,nFiles);
-    CovarianceDepthDensityDirect = cell(nDirectHorizon,nFiles); 
-    DirectSWE = cell(nDirectHorizon,nFiles); DirectSWEvar = cell(nDirectHorizon,nFiles);
-    
-    % Allocate for Concatenation and Plotting
-    dhTWT = cell(nDirectHorizon,nFiles); dhTWTvar = cell(nDirectHorizon,nFiles);
-    dhSnowWaterEqv = cell(nDirectHorizon,nFiles);dhSnowWaterEqvVar = cell(nDirectHorizon,nFiles);
-    dhDensity = cell(nDirectHorizon,nFiles); dhDensityVar = cell(nDirectHorizon,nFiles); 
-    dhDepth = cell(nDirectHorizon,nFiles); dhDepthVar = cell(nDirectHorizon,nFiles);
-   
-    % Allocate Bootstrapping of RMS Velocity
-    xVref = cell(nReflectionHorizon,nTrace,nFiles);xToRef = cell(nReflectionHorizon,nTrace,nFiles);
-    xDepth = cell(nReflectionHorizon,nTrace,nFiles);xRhoRef = cell(nReflectionHorizon,nTrace,nFiles);
-    VoRef = cell(nReflectionHorizon,nTrace,nFiles);VoVarRef = cell(nReflectionHorizon,nTrace,nFiles);
-    toRef = cell(nReflectionHorizon,nTrace,nFiles);toVarRef = cell(nReflectionHorizon,nTrace,nFiles);
-    HorizonDepth = cell(nReflectionHorizon,nTrace,nFiles);RhoRef = cell(nReflectionHorizon,nTrace,nFiles);
-    HorizonDepthVar = cell(nReflectionHorizon,nTrace,nFiles);RhoRefVar = cell(nReflectionHorizon,nTrace,nFiles);
-    CovDepthRho = cell(nReflectionHorizon,nTrace,nFiles);
-    
-    % Allocation for Interval Velocities
-    xVint = cell(nReflectionHorizon,nTrace,nFiles);xHint = cell(nReflectionHorizon,nTrace,nFiles);
-    VoInt = cell(nReflectionHorizon,nTrace,nFiles);VoIntVar = cell(nReflectionHorizon,nTrace,nFiles);
-    HoInt = cell(nReflectionHorizon,nTrace,nFiles);HoIntVar = cell(nReflectionHorizon,nTrace,nFiles);
-    xRhoInt = cell(nReflectionHorizon,nTrace,nFiles); RhoInt = cell(nReflectionHorizon,nTrace,nFiles);
-    RhoIntVar = cell(nReflectionHorizon,nTrace,nFiles);CovThicknessRho = cell(nReflectionHorizon,nTrace,nFiles);      
-    
-    % Allocate for Concatenation and Plotting    
-    ReflectionVelocity = cell(nReflectionHorizon,nFiles);
-    ReflectionVelocityVar = cell(nReflectionHorizon,nFiles);ReflectionDepth = cell(nReflectionHorizon,nFiles);
-    ReflectionDepthVar = cell(nReflectionHorizon,nFiles);ReflectionDensity = cell(nReflectionHorizon,nFiles);
-    ReflectionDensityVar = cell(nReflectionHorizon,nFiles);CovarianceDepthDensity = cell(nReflectionHorizon,nFiles);
-    ReflectionTo = cell(nReflectionHorizon,nFiles); ReflectionToVar = cell(nReflectionHorizon,nFiles);
-    IntervalVelocity = cell(nReflectionHorizon,nFiles);IntervalVelocityVar = cell(nReflectionHorizon,nFiles);
-    IntervalThickness = cell(nReflectionHorizon,nFiles);IntervalThicknessVar = cell(nReflectionHorizon,nFiles);
-    IntervalDensity = cell(nReflectionHorizon,nFiles);IntervalDensityVar = cell(nReflectionHorizon,nFiles);
-    CovarianceThicknessDensity = cell(nReflectionHorizon,nFiles);
-    
-    % Allocation for Results
-    SWE = cell(nReflectionHorizon,nFiles);SWEvar = cell(nReflectionHorizon,nFiles);
-    SWEint = cell(nReflectionHorizon,nFiles);SWEintVar = cell(nReflectionHorizon,nFiles);
-    TWT = cell(nReflectionHorizon,nFiles);TWTvar = cell(nReflectionHorizon,nFiles);
-    SnowWaterEqv = cell(nReflectionHorizon,nFiles);SnowWaterEqvVar = cell(nReflectionHorizon,nFiles);
-    Density = cell(nReflectionHorizon,nFiles); DensityVar = cell(nReflectionHorizon,nFiles);
-    Depth = cell(nReflectionHorizon,nFiles); DepthVar = cell(nReflectionHorizon,nFiles);
-    LayerSnowWaterEqv = cell(nReflectionHorizon,nFiles);LayerSnowWaterEqvVar = cell(nReflectionHorizon,nFiles);
-    LayerDensity = cell(nReflectionHorizon,nFiles);LayerDensityVar = cell(nReflectionHorizon,nFiles);
-    LayerThickness = cell(nReflectionHorizon,nFiles);LayerThicknessVar = cell(nReflectionHorizon,nFiles);    
-    
+% Run Memory Allocation    
+HVAmemoryAllocation
+
 % Extract AirWave Picks and Perform Residual Subtraction Velocity Analysis
 %     parfor (ii = 1:nFiles, nWorkers - (nWorkers-nFiles)) 
     for ii = 1:nFiles
@@ -641,13 +609,13 @@ if isSWEDISH
                     end
                     
                     % Estimate Wavelet Depth
-                    xDepthDir{dh,jj,ii} = xVdir{dh,jj,ii}.*xToDir{dh,jj,ii};
+                    xDepthDir{dh,jj,ii} = xVdir{dh,jj,ii}.*abs(xToDir{dh,jj,ii});
                     % Estimate Direct Wave Density
                     xRhoDir{dh,jj,ii} = DryCrim([xVdir{dh,jj,ii}]);
                     % Error Analysis
                     VoDir{dh,jj,ii} = mean([xVdir{dh,jj,ii}]);
                     VoVarDir{dh,jj,ii} = var([xVdir{dh,jj,ii}]);
-                    toDir{dh,jj,ii} = mean([xToDir{dh,jj,ii}]);
+                    toDir{dh,jj,ii} = mean(abs([xToDir{dh,jj,ii}]));
                     toVarDir{dh,jj,ii} = var([xToDir{dh,jj,ii}]);
                     DepthDir{dh,jj,ii} = mean([xDepthDir{dh,jj,ii}]);
                     RhoDir{dh,jj,ii} = mean([xRhoDir{dh,jj,ii}]);
@@ -911,6 +879,30 @@ else    % If No Time Correction is Used ~ Not Recommended
         time{ii} = [0:dt:(size(Radar{ii,1},1)-(1+padding(ii)))*dt];
     end
 end
+
+%% Save HVA Output
+isSaveHVA = 0;
+if isSaveHVA
+    % Save Rough Results
+    HVAfilename = '6-2-16-Core7-Spur-W-HVA.mat';
+    save(HVAfilename,'DirectTo','DirectToVar','deltaT',...
+    'DirectVelocity','DirectVelocityVar','DirectDepth','DirectDepthVar',...
+    'DirectDensity','DirectDensityVar','CovarianceDepthDensityDirect',...
+    'DirectSWE','DirectSWEvar','ReflectionTo','ReflectionToVar',...
+    'ReflectionVelocity','ReflectionVelocityVar','IntervalVelocity',...
+    'IntervalVelocityVar','ReflectionDepth','ReflectionDepthVar',...
+    'IntervalThickness','IntervalThicknessVar','ReflectionDensity',...
+    'ReflectionDensityVar','IntervalDensity','IntervalDensityVar',...
+    'CovarianceDepthDensity','CovarianceThicknessDensity','SWE','SWEint',...
+    'SWEvar','SWEintVar','-v7.3');
+
+    % Save Smooth Results
+    HVAsmoothFilename = '6-2-16-Core7-Spur-W-HVA.mat';
+    save(HVAsmoothFilename,'TWT','TWTvar','SnowWaterEqv',...
+        'SnowWaterEqvVar','Density','DensityVar','Depth','DepthVar','LayerSnowWaterEqv',...
+        'LayerSnowWaterEqvVar','LayerDensity','LayerDensityVar','LayerThickness',...
+        'LayerThicknessVar','-v7.3');
+end
 %% Create Figures for Snow Surface Data
 if isSWEDISH
     % plot Direct Wave Data
@@ -986,623 +978,3 @@ if isSWEDISH
             'FontWeight','Bold', 'LineWidth', 1);
     end
 end
-%% Old Version 9 - 5 - 17    
-%     %% Semi-Automatic Radar Wave Picking
-%     fprintf('Begin PolarPicker \n')
-%     display(' ')
-%     tic
-%     
-%     pickRadar = Radar;
-% 
-%     % AGC Gain for PolarPicker 
-%     for ii = 1:nFiles
-%         parfor (jj = chan, nWorkers)
-%             pickRadar{jj,ii} = AGCgain(pickRadar{jj,ii},50,2);
-%         end
-%     end
-%     
-%     % Pick AirWave Arrival
-%     display('Pick Air Wave')
-%     display(' ')
-%     [~, AirFBpick] = polarPicker(pickRadar);
-%     
-%     % Pick Primary Reflection Arrival
-%     display('Pick Primary Reflection')
-%     display(' ')
-%     [~, ReflectionFBpick] = polarPicker(pickRadar);
-%     
-%     clear pickRadar
-%     
-%     % Determine Number of Horizons
-%     nHorizon = size(ReflectionFBpick,2);
-%   
-% %     % Apply Systematic Correction to First Break Picks
-% %         time = cell(1,nFiles);
-% %         for ii = 1:nFiles
-% %             for jj = 1:nChan
-% %                 ReflectionFBpick{jj,ii} = (ReflectionFBpick{jj,ii} - chanShift(jj));
-% %                 AirFBpick{jj,ii} = (AirFBpick{jj,ii} - chanShift(jj));
-% %             end
-% %         end
-%         
-% % Convert Samples to ns
-% for ii = 1:nFiles
-%     time{ii} = [0:dt:(size(Radar{ii,1},1)-(1+padding(ii)))*dt];
-%     for jj = chan
-%         AirFBpick{jj,ii} = AirFBpick{jj,ii}.*dt;
-%         for hh = 1:nHorizon
-%             ReflectionFBpick{jj,hh,ii} = ReflectionFBpick{jj,hh,ii}.*dt;
-%         end
-%     end
-% end
-% 
-%     fprintf('PolarPicker Done \n')
-%     toc
-%     display(' ')
-%         
-% %% Perform Horizon Velocity Analysis for Estimates of Density, Depth, & SWE
-% % First Horizon has Bad to and depth Complex. Perhaps Bad Picks
-%     fprintf('Begin Surface Velocity Analysis \n')
-%     display(' ')
-%     tic
-%     
-%     % Determin Maximum File Size
-%     for ii = 1:nFiles
-%         nTrace(ii) = length(Radar{1,ii});
-%     end
-%     nTrace = max(nTrace);
-%         
-%     % Allocate Memory
-%     GatherReflectionPicks = cell(nHorizon,nFiles);
-%     GatherAirPicks = cell(1,nFiles);
-%     
-%     xVair = cell(nFiles,nTrace);xToAir = cell(nFiles,nTrace);
-%     VoAir = cell(nFiles,nTrace);VoVarAir = cell(nFiles,nTrace);
-%     toAir = cell(nFiles,nTrace);toVarAir = cell(nFiles,nTrace);
-%     AirVelocity = cell(nFiles,1);AirDensity = cell(nFiles,1); 
-%     deltaTair = cell(nFiles,nTrace);ResGatherAirPicks = cell(nFiles,nTrace);
-%    
-%     xVref = cell(nHorizon,nTrace,nFiles);xToRef = cell(nHorizon,nTrace,nFiles);
-%     xDepth = cell(nHorizon,nTrace,nFiles);xRhoRef = cell(nHorizon,nTrace,nFiles);
-%     VoRef = cell(nHorizon,nTrace,nFiles);VoVarRef = cell(nHorizon,nTrace,nFiles);
-%     toRef = cell(nHorizon,nTrace,nFiles);toVarRef = cell(nHorizon,nTrace,nFiles);
-%     HorizonDepth = cell(nHorizon,nTrace,nFiles);RhoRef = cell(nHorizon,nTrace,nFiles);
-%     HorizonDepthVar = cell(nHorizon,nTrace,nFiles);RhoRefVar = cell(nHorizon,nTrace,nFiles);
-%     CovDepthRho = cell(nHorizon,nTrace,nFiles);ReflectionVelocity = cell(nHorizon,nFiles);
-%     ReflectionVelocityVar = cell(nHorizon,nFiles);ReflectionDepth = cell(nHorizon,nFiles);
-%     ReflectionDepthVar = cell(nHorizon,nFiles);ReflectionDensity = cell(nHorizon,nFiles);
-%     ReflectionDensityVar = cell(nHorizon,nFiles);CovarianceDepthDensity = cell(nHorizon,nFiles);
-%     ReflectionTo = cell(nHorizon,nFiles); ReflectionToVar = cell(nHorizon,nFiles);
-%     SWE = cell(nHorizon,nFiles);SWEvar = cell(nHorizon,nFiles);
-%     TWT = cell(nHorizon,nFiles);TWTvar = cell(nHorizon,nFiles);
-%     SnowWaterEqv = cell(nHorizon,nFiles);SnowWaterEqvVar = cell(nHorizon,nFiles);
-%     Density = cell(nHorizon,nFiles); DensityVar = cell(nHorizon,nFiles);
-%     Depth = cell(nHorizon,nFiles); DepthVar = cell(nHorizon,nFiles);
-%     
-% % Extract AirWave Picks and Perform Residual Subtraction Velocity Analysis
-% %     parfor (ii = 1:nFiles, nWorkers - (nWorkers-nFiles)) 
-%     for ii = 1:nFiles
-%         looper = 1:length(Radar{ii});
-%         % Concatenate Air Wave Picks
-%         GatherAirPicks{ii} = cat(2,AirFBpick{:,ii});
-%         Air = GatherAirPicks{ii};
-%         % Air Wave Velocity Analysis      
-%         parfor (jj = looper, nWorkers)
-% %         for jj = 1:length(Radar{ii})
-%             % Extract Picks
-%             AirPick = Air(jj,:); 
-%             
-%             for kk = 1:100 % 100 Random Draws
-%                 % Cross-Validation for Surface Velocity Estimation 7-28-17
-%                 nCut = randsample([0,1,2],1);
-%                 cutChan = randsample(liveChan,nCut);
-%                 xvalChan = liveChan;
-%                 cutIx = find(ismember(liveChan,cutChan));
-%                 xvalChan(cutIx) = [];
-%                 xvalIx = find(ismember(xvalChan,liveChan));
-%                 
-%                 xvalAirPick = AirPick(xvalIx);
-%                 xvalOffset = offsetArray(xvalIx);
-%                 
-%                 % Compute Air Wave Arrival Velocity and Intercept Time
-%                 % OLS Scheme
-% %                 [xVair{ii,jj}(kk,1), ~] = DirectWave(xvalOffset,xvalAirPick);
-%                 % IRLS Scheme
-%                 [xVair{ii,jj}(kk,1), xToAir{ii,jj}(kk,1)] = DirectWaveIrls(xvalOffset,xvalAirPick);                
-%             end
-% 
-%             % Residual Error Analysis 
-%             VoAir{ii,jj} = mean([xVair{ii,jj}]);
-% 
-%             % Find Velocity Residual for Additional Trace Shifts & Calulate Residual Time
-%             deltaTair{ii,jj} = (offsetArray./VoAir{ii,jj}) - (offsetArray./0.299);
-% 
-%             % Apply Residual Time Shifts
-%             ResGatherAirPicks{ii,jj} = Air(jj,:) - deltaTair{ii,jj};
-% 
-%             % Re-Extract Airwave Picks after Residual Shifts
-%             AirPick = ResGatherAirPicks{ii,jj}; 
-%             
-%             for kk = 1:100 % 100 Random Draws
-%                 % Cross-Validation for Surface Velocity Estimation 7-28-17
-%                 nCut = randsample([0,1,2],1);
-%                 cutChan = randsample(liveChan,nCut);
-%                 xvalChan = liveChan;
-%                 cutIx = find(ismember(liveChan,cutChan));
-%                 xvalChan(cutIx) = [];                
-%                 xvalIx = find(ismember(xvalChan,liveChan));
-%                 
-%                 xvalAirPick = AirPick(xvalIx);
-%                 xvalOffset = offsetArray(xvalIx);
-%                 
-%                 % Compute Air Wave Arrival Velocity and Intercept Time
-%                 % OLS Scheme
-% %                 [xVair{ii,jj}(kk,1), xToAir{ii,jj}(kk,1)] = DirectWave(xvalOffset,xvalAirPick);
-%                 % IRLS Scheme
-%                 [xVair{ii,jj}(kk,1), xToAir{ii,jj}(kk,1)] = DirectWaveIrls(xvalOffset,xvalAirPick);                
-%             end
-%             % Error Analysis 
-%             VoAir{ii,jj} = mean([xVair{ii,jj}]);
-%             VoVarAir{ii,jj} = var([xVair{ii,jj}]);
-%             toAir{ii,jj} = mean([xToAir{ii,jj}]);
-%             toVarAir{ii,jj} = var([xToAir{ii,jj}]);
-%         end
-%         % Concatenate Air Velocity
-%         AirVelocity{ii} = [VoAir{ii,:}];
-%         % Estimate Air Density
-%         AirDensity{ii} = DryCrim(AirVelocity{ii});
-%     end
-%             
-% 
-% % Primary Reflection Velocity Analysis               
-%     for ii = 1:nFiles
-%         looper = 1:length(Radar{ii});
-%         for hh = 1:nHorizon
-%         % Concatenate Primary Reflection Picks for Horizon hh
-%         GatherReflectionPicks{hh,ii} = cat(2,ReflectionFBpick{:,hh,ii});
-%         Reflection = GatherReflectionPicks{hh,ii};
-% %         for jj = 1:length(Radar{ii})
-%         parfor (jj = looper, nWorkers)
-%             % Cross-Validation for Reflection Velocity Estimation
-%             % Multiple Shot Gathers in Population
-%             isManyShots = 0;
-%             if isManyShots
-%                 range = sqrt(([1:length(Radar{ii})]-jj).^2); % Compute Distance
-%                 getIx = find(range<=5); % Find Nearby Picks
-%                 RefPick = GatherReflectionPicks{ii}(getIx,:) - vertcat(deltaTair{ii,getIx}); % Residual
-%                 RefPick = RefPick - vertcat(toAir{ii,getIx})*ones(1,nChan);
-%                 stdRefPick = std(RefPick,0,1);
-%             end
-%             % Single Shot Gather in Population
-%             isSingleShot = 1;
-%             if isSingleShot
-%                 RefPick = Reflection(jj,:) - deltaTair{ii,jj}; % Residual
-%                 RefPick = RefPick - toAir{ii,jj};
-%             end
-% 
-%             for kk = 1:100 % 100 Random Draws
-%                 % Cross-Validation for Surface Velocity Estimation 7-28-17
-%                 nCut = randsample([0,1,2],1);
-%                 cutChan = randsample(liveChan,nCut);
-%                 xvalChan = liveChan;
-%                 cutIx = find(ismember(liveChan,cutChan));
-%                 xvalChan(cutIx) = [];                
-%                 xvalIx = find(ismember(xvalChan,liveChan));
-%                 
-%                 xvalRefPick = RefPick(xvalIx);
-%                 xvalOffset = offsetArray(xvalIx);
-%                 
-%                 % Compute Reflected Arrival Velocity and Intercept Time
-%                 % OLS Scheme
-% %                 [xVref{ii,jj}(kk,1), xToRef{ii,jj}(kk,1), xDepth{ii,jj}(kk,1)] ...
-% %                     = Vrms(xvalOffset,xvalRefPick);
-%                 % IRLS Scheme
-% %                 [xVref{hh,jj,ii}(kk,1), xToRef{hh,jj,ii}(kk,1), xDepth{hh,jj,ii}(kk,1)] ...
-% %                     = VrmsIrls(xvalOffset,xvalRefPick);
-%                 % Linear Arrival Approach
-%                 [xVref{hh,jj,ii}(kk,1), xToRef{hh,jj,ii}(kk,1)] ...
-%                     = DirectWaveIrls(xvalOffset,xvalRefPick);
-% %                 xToRef{hh,jj,ii} = abs(xToRef{hh,jj,ii}(kk,1));
-%                 xDepth{hh,jj,ii}(kk,1) = xVref{hh,jj,ii}(kk,1).*xToRef{hh,jj,ii}(kk,1);
-%             end
-% %             xToRef{hh,jj,ii} = abs(xToRef{hh,jj,ii});
-% %             xDepth{hh,jj,ii} = abs(xDepth{hh,jj,ii});
-%             xDepth{hh,jj,ii} = xVref{hh,jj,ii}.*xToRef{hh,jj,ii};
-%             % Create Random Sample Population of Surface Density
-%             xRhoRef{hh,jj,ii} = DryCrim([xVref{hh,jj,ii}]);
-%             
-%             % Error Analysis
-%             realIx = find(real([xToRef{hh,jj,ii}]));
-%             VoRef{hh,jj,ii} = mean([xVref{hh,jj,ii}(realIx)]);
-%             VoVarRef{hh,jj,ii} = var([xVref{hh,jj,ii}(realIx)]);
-%             toRef{hh,jj,ii} = mean([xToRef{hh,jj,ii}(realIx)]);
-%             toVarRef{hh,jj,ii} = var([xToRef{hh,jj,ii}(realIx)]);
-%             HorizonDepth{hh,jj,ii} = mean([xDepth{hh,jj,ii}(realIx)]);
-%             RhoRef{hh,jj,ii} = mean([xRhoRef{hh,jj,ii}(realIx)]);
-%             CovZP = cov([xDepth{hh,jj,ii}(realIx)],[xRhoRef{hh,jj,ii}(realIx)]);
-%             HorizonDepthVar{hh,jj,ii} = CovZP(1,1);
-%             RhoRefVar{hh,jj,ii} = CovZP(2,2);
-%             CovDepthRho{hh,jj,ii} = CovZP(1,2);
-%             
-%         end
-%         % Concatenate Reflection Travel Time
-%         ReflectionTo{hh,ii} = [toRef{hh,:,ii}];
-%         ReflectionToVar{hh,ii} = [toVarRef{hh,:,ii}];
-%         % Concatenate Reflection Velocity
-%         ReflectionVelocity{hh,ii} = [VoRef{hh,:,ii}];
-%         ReflectionVelocityVar{hh,ii} = [VoVarRef{hh,:,ii}];
-%         % Concatenate Reflector Depth
-%         ReflectionDepth{hh,ii} = [HorizonDepth{hh,:,ii}];
-%         ReflectionDepthVar{hh,ii} = [HorizonDepthVar{hh,:,ii}];
-%         % Concatenate Reflection Density & Convert Units
-%         ReflectionDensity{hh,ii} = [RhoRef{hh,:,ii}];
-%         ReflectionDensityVar{hh,ii} = [RhoRefVar{hh,:,ii}];
-%         % Concatenate Covariance
-%         CovarianceDepthDensity{hh,ii} = [CovDepthRho{hh,:,ii}];
-%         
-%         % Estimte SWE
-%         SWE{hh,ii} = ReflectionDepth{hh,ii}.*ReflectionDensity{hh,ii};
-%         % Error Propagation Equation
-%         SWEvar{hh,ii} = ReflectionDepthVar{hh,ii}.*ReflectionDensity{hh,ii}.^2 ...
-%             + ReflectionDensityVar{hh,ii}.*ReflectionDepth{hh,ii}.^2 ...
-%             + 2.*ReflectionDepth{hh,ii}.*ReflectionDensity{hh,ii}.*CovarianceDepthDensity{hh,ii};
-%         
-%         % Smooth Esitmates
-%         smoothR = 251;
-%         TWT{hh,ii} = nonParametricSmooth( 1:length(ReflectionTo{hh,ii}),...
-%             ReflectionTo{hh,ii},1:length(ReflectionTo{hh,ii}),smoothR);
-%         TWTvar{hh,ii} = nonParametricSmooth( 1:length(ReflectionToVar{hh,ii}),...
-%             ReflectionToVar{hh,ii},1:length(ReflectionToVar{hh,ii}),smoothR);
-%         SnowWaterEqv{hh,ii} = nonParametricSmooth( 1:length(SWE{hh,ii}),SWE{hh,ii},...
-%             1:length(SWE{hh,ii}),smoothR);
-%         SnowWaterEqvVar{hh,ii} = nonParametricSmooth( 1:length(SWEvar{hh,ii}),...
-%             SWEvar{hh,ii},1:length(SWEvar{hh,ii}),smoothR);
-%         Density{hh,ii} = nonParametricSmooth( 1:length(ReflectionDensity{hh,ii}),...
-%             ReflectionDensity{hh,ii},1:length(ReflectionDensity{hh,ii}),smoothR);
-%         DensityVar{hh,ii} = nonParametricSmooth( 1:length(ReflectionDensityVar{hh,ii}),...
-%             ReflectionDensityVar{hh,ii},1:length(ReflectionDensityVar{hh,ii}),smoothR);
-%         Depth{hh,ii} = nonParametricSmooth( 1:length(ReflectionDepth{hh,ii}),...
-%             ReflectionDepth{hh,ii},1:length(ReflectionDepth{hh,ii}),smoothR);
-%         DepthVar{hh,ii} = nonParametricSmooth( 1:length(ReflectionDepthVar{hh,ii}),...
-%             ReflectionDepthVar{hh,ii},1:length(ReflectionDepthVar{hh,ii}),smoothR);
-%         end
-%     end
-%     
-%     fprintf('Surface Velocity Analysis Done \n')
-%     toc
-%     display(' ')
-% 
-% else    % If No Time Correction is Used ~ Not Recommended
-%     for ii = 1:nFiles
-%         % Record Time
-%         time{ii} = [0:dt:(size(Radar{ii,1},1)-(1+padding(ii)))*dt];
-%     end
-% end
-
-%% Old Verion
-% %% Perform Surface Velocity Analysis for Estimates of Density, Depth, & SWE
-% 
-%     fprintf('Begin Surface Velocity Analysis \n')
-%     display(' ')
-%     tic
-%     
-%     % Determin Maximum File Size
-%     for ii = 1:nFiles
-%         nTrace(ii) = length(Radar{1,ii});
-%     end
-%     nTrace = max(nTrace);
-%     
-%     % Allocate Memory
-%     GatherReflectionPicks = cell(1,nFiles);
-%     GatherAirPicks = cell(1,nFiles);
-%     
-%     xVair = cell(nFiles,nTrace);xToAir = cell(nFiles,nTrace);
-%     VoAir = cell(nFiles,nTrace);VoVarAir = cell(nFiles,nTrace);
-%     toAir = cell(nFiles,nTrace);toVarAir = cell(nFiles,nTrace);
-%    
-%     xVref = cell(nFiles,nTrace);xToRef = cell(nFiles,nTrace);xDepth = cell(nFiles,nTrace);
-%     xRhoRef = cell(nFiles,nTrace);VoRef = cell(nFiles,nTrace);VoVarRef = cell(nFiles,nTrace);
-%     toRef = cell(nFiles,nTrace);toVarRef = cell(nFiles,nTrace);Depth = cell(nFiles,nTrace);
-%     RhoRef = cell(nFiles,nTrace);DepthVar = cell(nFiles,nTrace);RhoRefVar = cell(nFiles,nTrace);
-%     CovDepthRho = cell(nFiles,nTrace);ReflectionVelocity = cell(1,nFiles);
-%     ReflectionVelocityVar = cell(1,nFiles);ReflectionDepth = cell(1,nFiles);
-%     ReflectionDepthVar = cell(1,nFiles);ReflectionDensity = cell(1,nFiles);
-%     ReflectionDensityVar = cell(1,nFiles);CovarianceDepthDensity = cell(1,nFiles);
-%     ReflectionTo = cell(1,nFiles); ReflectionToVar = cell(1,nFiles);
-%     SWE = cell(1,nFiles);SWEvar = cell(1,nFiles);AirVelocity = cell(nFiles,nTrace);
-%     AirDensity = cell(nFiles,nTrace); deltaTair = cell(nFiles,nTrace);
-%     ResGatherAirPicks = cell(nFiles,nTrace);
-% 
-% % Extract AirWave Picks and Perform Residual Subtraction Velocity Analysis
-% %     parfor (ii = 1:nFiles, nWorkers - (nWorkers-nFiles)) 
-%     for ii = 1:nFiles
-%         looper = 1:length(Radar{ii});
-%         % Concatenate Air Wave Picks
-%         GatherAirPicks{ii} = cat(2,AirFBpick{:,ii});
-%         Air = GatherAirPicks{ii};
-%         % Air Wave Velocity Analysis      
-%         parfor (jj = looper, nWorkers)
-% %         for jj = 1:length(Radar{ii})
-%             % Extract Picks
-%             AirPick = Air(jj,:); 
-%             
-%             for kk = 1:100 % 100 Random Draws
-%                 % Cross-Validation for Surface Velocity Estimation 7-28-17
-%                 nCut = randsample([0,1,2],1);
-%                 cutChan = randsample(liveChan,nCut);
-%                 xvalChan = liveChan;
-%                 cutIx = find(ismember(liveChan,cutChan));
-%                 xvalChan(cutIx) = [];
-%                 xvalIx = find(ismember(xvalChan,liveChan));
-%                 
-%                 xvalAirPick = AirPick(xvalIx);
-%                 xvalOffset = offsetArray(xvalIx);
-%                 
-%                 % Compute Air Wave Arrival Velocity and Intercept Time
-%                 % OLS Scheme
-% %                 [xVair{ii,jj}(kk,1), ~] = DirectWave(xvalOffset,xvalAirPick);
-%                 % IRLS Scheme
-%                 [xVair{ii,jj}(kk,1), xToAir{ii,jj}(kk,1)] = DirectWaveIrls(xvalOffset,xvalAirPick);                
-%             end
-% 
-%             % Residual Error Analysis 
-%             VoAir{ii,jj} = mean([xVair{ii,jj}]);
-% 
-%             % Find Velocity Residual for Additional Trace Shifts & Calulate Residual Time
-%             deltaTair{ii,jj} = (offsetArray./VoAir{ii,jj}) - (offsetArray./0.299);
-% 
-%             % Apply Residual Time Shifts
-%             ResGatherAirPicks{ii,jj} = Air(jj,:) - deltaTair{ii,jj};
-% 
-%             % Re-Extract Airwave Picks after Residual Shifts
-%             AirPick = ResGatherAirPicks{ii,jj}; 
-%             
-%             for kk = 1:100 % 100 Random Draws
-%                 % Cross-Validation for Surface Velocity Estimation 7-28-17
-%                 nCut = randsample([0,1,2],1);
-%                 cutChan = randsample(liveChan,nCut);
-%                 xvalChan = liveChan;
-%                 cutIx = find(ismember(liveChan,cutChan));
-%                 xvalChan(cutIx) = [];                
-%                 xvalIx = find(ismember(xvalChan,liveChan));
-%                 
-%                 xvalAirPick = AirPick(xvalIx);
-%                 xvalOffset = offsetArray(xvalIx);
-%                 
-%                 % Compute Air Wave Arrival Velocity and Intercept Time
-%                 % OLS Scheme
-% %                 [xVair{ii,jj}(kk,1), xToAir{ii,jj}(kk,1)] = DirectWave(xvalOffset,xvalAirPick);
-%                 % IRLS Scheme
-%                 [xVair{ii,jj}(kk,1), xToAir{ii,jj}(kk,1)] = DirectWaveIrls(xvalOffset,xvalAirPick);                
-%             end
-%             % Error Analysis 
-%             VoAir{ii,jj} = mean([xVair{ii,jj}]);
-%             VoVarAir{ii,jj} = var([xVair{ii,jj}]);
-%             toAir{ii,jj} = mean([xToAir{ii,jj}]);
-%             toVarAir{ii,jj} = var([xToAir{ii,jj}]);
-%         end
-%         % Concatenate Air Velocity
-%         AirVelocity{ii} = [VoAir{ii,:}];
-%         % Estimate Air Density
-%         AirDensity{ii} = DryCrim(AirVelocity{ii});
-%     end
-%             
-% 
-% % Primary Reflection Velocity Analysis               
-%     for ii = 1:nFiles
-%         looper = 1:length(Radar{ii});
-%         % Concatenate Primary Reflection Picks
-%         GatherReflectionPicks{ii} = cat(2,ReflectionFBpick{:,ii});
-%         Reflection = GatherReflectionPicks{ii};
-% %         for jj = 1:length(Radar{ii})
-%         parfor (jj = looper, nWorkers)
-%             % Cross-Validation for Reflection Velocity Estimation
-%             % Multiple Shot Gathers in Population
-%             isManyShots = 0;
-%             if isManyShots
-%                 range = sqrt(([1:length(Radar{ii})]-jj).^2); % Compute Distance
-%                 getIx = find(range<=5); % Find Nearby Picks
-%                 RefPick = GatherReflectionPicks{ii}(getIx,:) - vertcat(deltaTair{ii,getIx}); % Residual
-%                 RefPick = RefPick - vertcat(toAir{ii,getIx})*ones(1,nChan);
-%                 stdRefPick = std(RefPick,0,1);
-%             end
-%             % Single Shot Gather in Population
-%             isSingleShot = 1;
-%             if isSingleShot
-%                 RefPick = Reflection(jj,:) - deltaTair{ii,jj}; % Residual
-%                 RefPick = RefPick - toAir{ii,jj};
-%             end
-% 
-%             for kk = 1:100 % 100 Random Draws
-%                 % Cross-Validation for Surface Velocity Estimation 7-28-17
-%                 nCut = randsample([0,1,2],1);
-%                 cutChan = randsample(liveChan,nCut);
-%                 xvalChan = liveChan;
-%                 cutIx = find(ismember(liveChan,cutChan));
-%                 xvalChan(cutIx) = [];                
-%                 xvalIx = find(ismember(xvalChan,liveChan));
-%                 
-%                 xvalRefPick = RefPick(xvalIx);
-%                 xvalOffset = offsetArray(xvalIx);
-%                 
-%                 % Compute Reflected Arrival Velocity and Intercept Time
-%                 % OLS Scheme
-% %                 [xVref{ii,jj}(kk,1), xToRef{ii,jj}(kk,1), xDepth{ii,jj}(kk,1)] ...
-% %                     = Vrms(xvalOffset,xvalRefPick);
-%                 % IRLS Scheme
-%                 [xVref{ii,jj}(kk,1), xToRef{ii,jj}(kk,1), xDepth{ii,jj}(kk,1)] ...
-%                     = VrmsIrls(xvalOffset,xvalRefPick);
-%             end
-%             
-%             % Create Random Sample Population of Surface Density
-%             xRhoRef{ii,jj} = DryCrim([xVref{ii,jj}]);
-%             
-%             % Error Analysis
-%             realIx = find(real([xToRef{ii,jj}]));
-%             VoRef{ii,jj} = mean([xVref{ii,jj}(realIx)]);
-%             VoVarRef{ii,jj} = var([xVref{ii,jj}(realIx)]);
-%             toRef{ii,jj} = mean([xToRef{ii,jj}(realIx)]);
-%             toVarRef{ii,jj} = var([xToRef{ii,jj}(realIx)]);
-%             Depth{ii,jj} = mean([xDepth{ii,jj}(realIx)]);
-%             RhoRef{ii,jj} = mean([xRhoRef{ii,jj}(realIx)]);
-%             CovZP = cov([xDepth{ii,jj}(realIx)],[xRhoRef{ii,jj}(realIx)]);
-%             DepthVar{ii,jj} = CovZP(1,1);
-%             RhoRefVar{ii,jj} = CovZP(2,2);
-%             CovDepthRho{ii,jj} = CovZP(1,2);
-%             
-%         end
-%         % Concatenate Reflection Travel Time
-%         ReflectionTo{ii} = [toRef{ii,:}];
-%         ReflectionToVar{ii} = [toVarRef{ii,:}];
-%         % Concatenate Reflection Velocity
-%         ReflectionVelocity{ii} = [VoRef{ii,:}];
-%         ReflectionVelocityVar{ii} = [VoVarRef{ii,:}];
-%         % Concatenate Reflector Depth
-%         ReflectionDepth{ii} = [Depth{ii,:}];
-%         ReflectionDepthVar{ii} = [DepthVar{ii,:}];
-%         % Concatenate Reflection Density & Convert Units
-%         ReflectionDensity{ii} = [RhoRef{ii,:}];
-%         ReflectionDensityVar{ii} = [RhoRefVar{ii,:}];
-%         % Concatenate Covariance
-%         CovarianceDepthDensity{ii} = [CovDepthRho{ii,:}];
-%         
-%         % Estimte SWE
-%         SWE{ii} = ReflectionDepth{ii}.*ReflectionDensity{ii};
-%         % Error Propagation Equation
-%         SWEvar{ii} = ReflectionDepthVar{ii}.*ReflectionDensity{ii}.^2 ...
-%             + ReflectionDensityVar{ii}.*ReflectionDepth{ii}.^2 ...
-%             + 2.*ReflectionDepth{ii}.*ReflectionDensity{ii}.*CovarianceDepthDensity{ii};
-%         
-%         
-%     end
-% %     % Smooth Esitmates
-% %     Depth = ReflectionDepth{1};
-% %     Density = ReflectionDensity{1};
-% %     DensityVar = ReflectionDensityVar{1};
-% %     DepthVar = ReflectionDepthVar{1};
-% %     swe = SWE{1};
-% %     sweVar = SWEvar{1};
-% %     smoothSWE = conv(swe,hamming(251),'valid')./sum(hamming(251));
-% %     smoothSWEvar = conv(sweVar,hamming(251),'valid')./sum(hamming(251));
-% %     smoothDensity = conv(Density,hamming(251),'valid')./sum(hamming(251));
-% %     smoothDensityVar = conv(DensityVar,hamming(251),'valid')./sum(hamming(251));
-% %     smoothDepth = conv(Depth,hamming(251),'valid')./sum(hamming(251));
-% %     smoothDepthVar = conv(DepthVar,hamming(251),'valid')./sum(hamming(251));
-% %     
-% %     % Extrapolate Edges of Convolution
-% %     smoothSWE = [ones(1,floor(251/2)).*smoothSWE(1),...
-% %     smoothSWE,ones(1,floor(251/2)).*smoothSWE(end)];
-% %     smoothSWEvar = [ones(1,floor(251/2)).*smoothSWEvar(1),...
-% %     smoothSWEvar,ones(1,floor(251/2)).*smoothSWEvar(end)];
-% %     smoothDensity = [ones(1,floor(251/2)).*smoothDensity(1),...
-% %     smoothDensity,ones(1,floor(251/2)).*smoothDensity(end)];
-% %     smoothDensityVar = [ones(1,floor(251/2)).*smoothDensityVar(1),...
-% %     smoothDensityVar,ones(1,floor(251/2)).*smoothDensityVar(end)];
-% %     smoothDepth = [ones(1,floor(251/2)).*smoothDepth(1),...
-% %     smoothDepth,ones(1,floor(251/2)).*smoothDepth(end)];
-% %     smoothDepthVar = [ones(1,floor(251/2)).*smoothDepthVar(1),...
-% %     smoothDepthVar,ones(1,floor(251/2)).*smoothDepthVar(end)];
-% 
-%     % Smooth Esitmates
-%     TWT = ReflectionTo{1};
-%     TWTvar = ReflectionToVar{1};
-%     Depth = ReflectionDepth{1};
-%     Density = ReflectionDensity{1};
-%     DensityVar = ReflectionDensityVar{1};
-%     DepthVar = ReflectionDepthVar{1};
-%     swe = SWE{1};
-%     sweVar = SWEvar{1};
-%     smoothTWT = nonParametricSmooth( 1:length(TWT),TWT,1:length(TWT),251);
-%     smoothTWTvar = nonParametricSmooth( 1:length(TWTvar),TWTvar,1:length(TWTvar),251);
-%     smoothSWE = nonParametricSmooth( 1:length(swe),swe,1:length(swe),251);
-%     smoothSWEvar = nonParametricSmooth( 1:length(sweVar),sweVar,1:length(sweVar),251);
-%     smoothDensity = nonParametricSmooth( 1:length(Density),Density,1:length(Density),251);
-%     smoothDensityVar = nonParametricSmooth( 1:length(DensityVar),DensityVar,1:length(DensityVar),251);
-%     smoothDepth = nonParametricSmooth( 1:length(Depth),Depth,1:length(Depth),251);
-%     smoothDepthVar = nonParametricSmooth( 1:length(DepthVar),DepthVar,1:length(DepthVar),251);
-%     
-%     fprintf('Surface Velocity Analysis Done \n')
-%     toc
-%     display(' ')
-% 
-% else    % If No Time Correction is Used ~ Not Recommended
-%     for ii = 1:nFiles
-%         % Record Time
-%         time{ii} = [0:dt:(size(Radar{ii,1},1)-(1+padding(ii)))*dt];
-%     end
-% end
-
-% %% Create Figure
-% if isSWEDISH
-% figure();
-% subplot(3,1,1)
-% shadedErrorBarT8([],smoothSWE,sqrt(smoothSWEvar),1,{'Color',[0.5,0,0],'linewidth',1.5})
-% freezeColors
-% axis tight
-% grid on
-% title('Accumulation [m w.e.]') 
-% subplot(3,1,2)
-% shadedErrorBarT8([],smoothDensity.*1000,sqrt(smoothDensityVar).*1000,1,{'Color',[0,0,.5],'linewidth',1.5})
-% freezeColors
-% axis tight
-% grid on
-% title('Density [kgm^{-3}]') 
-% subplot(3,1,3)
-% shadedErrorBarT8([],smoothDepth,sqrt(smoothDepthVar),1,{'Color',[0,0,0],'linewidth',1.5})
-% freezeColors
-% axis tight
-% grid on
-% title('Depth [m]')
-% set(findobj(gcf,'type','axes'),'FontName','Arial','FontSize',12,'FontWeight','Bold', 'LineWidth', 1);
-% end
-%% Data Export
-%     % Create CMP Structure for Export of Data and Coherence Matrix
-%     field1 = 'CMP';         value1 = num2cell(selection);
-%     field2 = 'Offset';      value2 = selectOffsetArray;
-%     field3 = 'Location';    value3 = selectMidPointLoc;
-%     field4 = 'Trace';       value4 = selectTraceIxBin;
-%     field5 = 'Data';        value5 = selectProCMP;
-%     field6 = 'To';          value6 = to;
-%     field7 = 'Vo';          value7 = Vo;
-%     field8 = 'Time';        value8 = T;
-%     field9 = 'Velocity';    value9 = V;
-%     field10 = 'Semblance';   value10 = VelX;
-%     
-%     semblanceCMP = struct(field1,value1,field2,value2,field3,value3,field4,value4, ...
-%         field5,value5,field6,value6,field7,value7,field8,value8, field9, value9, field10, value10);
-%     
-%     % Smash Coherence Matrix
-%     stackS = cat(3,VelX{:});
-%     stackSemblance = sum(stackS,3);
-%     
-%     % Normalize Smashed Coherence Matrix
-%     SuperSemblance = stackSemblance/max(abs(stackSemblance(:)));
-%     % Create CMP Structure for Export of Data and Coherence Matrix
-%     field1 = 'DataTrueGain';        value1 = profileCMP{1}{157};
-%     field2 = 'DataAGCGain';         value2 = agcCMP{1}{157};
-%     field3 = 'Offset';          value3 = offsetArray;
-%     field4 = 'RecordTime';        value4 = time{1};
-%     field5 = 'StackingTime';      value5 = T;
-%     field6 = 'StackingVelocity';    value6 = V;
-%     field7 = 'VelocityCoherence';   value7 = veloGram{1}{157};
-%     
-%     dylanCMP = struct(field1,value1,field2,value2,field3,value3,field4,value4, ...
-%         field5,value5,field6,value6,field7,value7);
-%     
-%     if isWrite
-%         cd '/home/tatemeehan/GreenTracs2016/GREENLAND/#ProcessGreenland/GPRprocess/Save'
-%         save('TimeCorrectedCMP.mat','dylanCMP','-v7.3')
-%         % save('Core7Semblance.txt','V','T','S','-ascii')
-%         cd '/home/tatemeehan/GreenTracs2016/GREENLAND/#ProcessGreenland/GPRprocess/TM'
-%     end
-
-%     
-
-% 
-% % Write Data to .mat File
-% if isWrite
-%     cd '/home/tatemeehan/GreenTracs2016/GREENLAND/#ProcessGreenland/GPRprocess/Save'
-%     save('Core7SemblanceGuideR0CCkm.mat','semblanceCMP','-v7.3')
-%     % save('Core7Semblance.txt','V','T','S','-ascii')
-%     cd '/home/tatemeehan/GreenTracs2016/GREENLAND/#ProcessGreenland/GPRprocess/TM'
-% end


### PR DESCRIPTION
SWEDISH has been changed to branch processing for Direct and Reflected Arrivals.
The Median Subtraction Filter has been created and Implemented.
Common-offset Gathers will be plotted with a keyboard pause so the geophysicist may examin travel time horizons prior to picking.
polarPicker.m has been modified to in clude a zoom tool. Clear All picks is now an option at the end of horizon, so the user may repick if necessary.
DixHVA was slightly modified to correctly constrain velocity solutions. NaN solutions may occur, however.
Core7SpurWHVAanalysis reads the saved HVA results and compares them to the core 7 site.
movingVariance has not been tested.