### PR TITLE
Incorporated depth picking for additional accumulation update.

### DIFF
--- a/AgeToDepthConversion.m
+++ b/AgeToDepthConversion.m
@@ -1,0 +1,50 @@
+%% Stratigraphic Age to Depth Conversion
+%
+% Allocation
+RadarDepth = RadarDeposition;
+% Change to Age Depth Matrix
+    for ii = 1:nFiles
+        RadDeposit = RadarDeposition{ii};
+        [m,n] = size(RadarDeposition{ii});
+        m = m/q;
+        RadDepth = zeros(m,n);
+        DepositAxe = DepositionAxis{ii};
+        % ReSample in Age Domain
+%         DepositAxe = [linspace(min(DepositAxe),max(DepositAxe),q.*length(DepositAxe))]';
+        zStak = zStack{ii};
+        tStak = tStack{ii};
+        tmpModel = pseudoAgeModel{ii};
+        % Interpolation Axes
+        AxZ = linspace(min(zStak(:)),max(zStak(:)),m);
+        % Axis for Deposition Image
+%         if isPickAgeHorizons || isLoadIRH
+%             ageStak = depositionAgeModel{ii};
+%             DepositionAxis{ii} = (linspace(0,max(ageStak(:)),size(RadarDeposition{ii},1)))';
+%             DepositAxe = DepositionAxis{ii};
+%         else
+%         end
+        % Convert Stratigraphic Age Image to Depth Image
+        parfor (kk = 1:size(RadarDeposition{ii},2), nWorkers)
+%         for kk = 1:size(RadarDeposition{ii},2)
+            % Create the Conversion Axis Time 2 Age (TA)
+            tmpAxTA = interp1(tmpModel(:,kk),tStak(:,kk),DepositAxe,'linear');
+            nanIx = isnan(tmpAxTA);
+            tmpAxTA = tmpAxTA(~nanIx);
+            % Create the Conversion Axis Age 2 Depth (TZ)
+            tmpAxTZ = interp1(tStak(:,kk),zStak(:,kk),tmpAxTA,'linear');
+            mData = length(tmpAxTZ);
+
+            % Use interp1 Alg Here
+            tmpTrc = interp1(tmpAxTZ,RadDeposit(1:mData,kk),AxZ);
+            % Pad Interpolation with Zeros
+            RadDepth(:,kk) = [tmpTrc;zeros(m - length(tmpTrc),1)];
+
+            % [Age,Depth] - Array to be resampled
+%             azcurve = [tmpModel(:,kk),zStak(:,kk)];
+%             [RadDepth(:,kk)] = timeDepthConversion(RadDeposit(:,kk),azcurve,DepthAxe);
+        end
+        nanIx = isnan(RadDepth);
+        RadDepth(nanIx) = 0;
+        RadarDepth{ii} = RadDepth;
+    end
+    clear('RadDeposit','RadDepth','DepositAxe','zStak','ageStak','tmpModel','tStak','AxZ');%'RadarDeposition','DepositionAxis','depths'

--- a/CalculateAgeResidual.m
+++ b/CalculateAgeResidual.m
@@ -1,0 +1,57 @@
+%% Caclulate Stratigraphic Age Residual
+% The residual of the picked age-horizons is measured optionally against 
+% the nearby GreenTrACS firn core or the starting Age-Depth model.
+
+% Determine Number of Age Horizons
+nAgeHorizon = size(isochronePick,2);
+
+% Calculate Residual
+ageResidual = isochronePick;
+datumAge = zeros(nAgeHorizon,nFiles);
+warning('off','MATLAB:mir_warning_changing_try_catch');
+try iceCoreIx;
+catch
+    iceCoreIx = 1:100;
+end
+
+% Cacluate the Age Residual each row of the matrix should have the same age
+for ii = 1:nFiles
+    dAge = mean(diff(DepositionAxis{ii}));
+    for jj = 1;% chan (Loop over chan for Mx processing)
+             % Test for Age samples or Index
+            if all(max([isochronePick{jj,:,ii}]) > 25) % 25 samples/age threshold
+                isConvert = 1;
+            else
+                isConvert = 0;
+            end
+        for ah = 1:nAgeHorizon
+            if isConvert
+            % Convert Samples to Age
+            isochronePick{jj,ah,ii} = isochronePick{jj,ah,ii}.*dAge;
+            end
+            % Determine Measurement Datum
+            if isGreenTracsFirnCore
+                % ageDepth : Age is the linear Axis!
+                GTCageDepth = interp1(abs(GTCaz(:,1)-GTCaz(1,1)),GTCaz(:,2),DepositionAxis{ii},'pchip');
+                GTCageDepth = [DepositionAxis{ii},GTCageDepth];
+                % Grab the mean Starting Age-Depth Model at iceCoreIx
+                % Interpolate these depths to the Deposition Axis
+                % With this new axis find the Depths of the picks
+                %Find equivalent depths on GTC ageDepth axis
+                % Compute residual ages of equivalent depths
+                tmpA = mean(AgeModel{ii}(:,iceCoreIx),2);
+                tmpZ = mean(DepthMatrix{ii}(:,iceCoreIx),2);
+                tmp = interp1(tmpA,tmpZ,DepositionAxis{ii},'pchip');
+                modAgeDepth = [DepositionAxis{ii},tmp];
+                isochroneDepth(ah,ii) = modAgeDepth(round(mean(isochronePick{jj,ah,ii}(iceCoreIx)./dAge)),2);
+                [~,datumIx] = min(abs(GTCageDepth(:,2) - isochroneDepth(ah,ii)));
+            else
+                [~,datumIx] = min(abs(mean(isochronePick{jj,ah,ii}(iceCoreIx))-DepositionAxis{ii}));
+            end
+            datumAge(ah,ii) = DepositionAxis{ii}(datumIx);
+            % Calculate Misfit
+            ageResidual{jj,ah,ii} = isochronePick{jj,ah,ii} - datumAge(ah,ii);
+        end
+    end
+    clear ('tmp','tmpA','tmZ','modAgeDepth','datumIx','isConvert');%,'isochroneDepth','GTCageDepth',
+end

--- a/FirnAdvectionCorrection.m
+++ b/FirnAdvectionCorrection.m
@@ -1,0 +1,37 @@
+%% Lateral Firn Advection Correction
+% The age-depth model is regridded using new (X,Z) coordinates that are
+% determined by ice sheet surface velocities that are propagated backwards
+% in time. The NASA MEaSUREs Multi-year Greenland Ice Sheet Velocity Mosaic
+% Version 1 data are incorporated to make the advection model.
+
+if isLoadGPS && isMEaSUREs
+    for ii = 1:nFiles
+        measuresDir = '/home/tatemeehan/GreenTracs2017/MEaSUREs';
+        filenameX = 'greenland_vel_mosaic250_vx_v1.tif';
+        filenameY = 'greenland_vel_mosaic250_vy_v1.tif';
+        surfV = surfaceVelocity(measuresDir,filenameX,filenameY,trhd{ii});
+        % Compute X-Position Perturbation for Age Model
+        deltaX = surfV'.*AgeModel{ii};
+        % Filter Bad Perturbations due to Array Turning
+        % Forward Difference
+        fdiff = deltaX(end,1:end-99) - deltaX(end,100:end);
+        fix = find(fdiff > quantile(fdiff,0.99) | fdiff < quantile(fdiff,0.01)) + 99;
+        goodIx = find(~ismember(1:length(deltaX(end,:)),fix));
+        % Filter Discontinuities by Replacement with Nearest Neighbor
+        for kk = 1:length(fix)
+            [~,binix] = min(abs(fix(kk)-goodIx));
+            deltaX(:,fix(kk)) =  deltaX(:,binix);
+        end
+        
+        % Correct Depth-Age Model for Lateral Firn Advection
+        % Backward Propagation of X perturbations
+        dxStack = double(xStack{ii}-deltaX);
+        staticAgeModel = griddata(dxStack,DepthMatrix{ii},...
+            updateAgeModel{ii},xStack{ii},DepthMatrix{ii},'linear');
+        staticAgeModel = inpaint_nans(staticAgeModel,1);
+        staticAgeModel(1,:) = 0;
+        smoothStaticAgeModel = imgaussfilt(staticAgeModel,[1 25]);
+        accumulationFirnUpdate = ((DepthMatrix{ii}.*AvgDensityModel{ii})./(staticAgeModel+eps));
+        % Currenlty No Working Variables are Assigned
+    end
+end

--- a/MakeFigures.m
+++ b/MakeFigures.m
@@ -1,0 +1,523 @@
+    %% Plot Wiggle OverLay Velocity
+if isLoadMxHL
+    MxHLFilename = 'GTC15SpurWMxHL.mat';
+    % Load MxHL structure
+    load(MxHLFilename);
+    % Write Unpacked Structure Variables to .m file
+    structvars(GTC15SpurWMxHL);
+    % Run .m to Evaluate structvars
+    tmpvars
+    delete tmpvars.m
+    clear GTC15SpurWMxHL
+end
+if isDepthSection
+
+    for ii = 1:nFiles
+        %Create Transparancy Mask
+        WiggleAlpha = sign(RadarDepth{ii}); WiggleAlpha(WiggleAlpha<0) = 0;
+        WiggleAlpha = conv2(WiggleAlpha,triang(3),'same')./sum(triang(3));
+        WiggleAlpha = WiggleAlpha.*(tukeywin(size(WiggleAlpha,1),.09).*ones(1,size(WiggleAlpha,2)));
+        WiggleAlpha(WiggleAlpha<1) = 0;
+        % Plot Density, Overlay Peak Amplitudes
+        figure();imagesc(Traverse{ii}./1000,DepthAxis{ii},1000.*DensityModel{ii});colormap(yet_white);freezeColors;hold on;
+        imagesc(Traverse{ii}./1000,DepthAxis{ii},sign(RadarDepth{ii}),'AlphaData',WiggleAlpha);colormap([0,0,0]);freezeColors;
+        colormap(yet_white);hlay = colorbar; set(hlay,'YDir','reverse','fontsize',14,'fontweight','bold','Ticks',[310,350,400,450,500,550,600,625]);
+        set(get(hlay,'ylabel'),'String','Density [kg/m^{3}]', 'rotation', 270,'Units', 'Normalized', 'Position', [4, 0.5, 0])
+        title('Density Tomogram')
+        xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold')
+        set(gca,'YTick',[0,2.5,5,7.5,10,12.5,15,17.5,20,22.5])
+        
+        % Plot Density Anamoly, Overlay Peak Amplitudes
+%         figure();imagesc(Traverse{ii}./1000,DepthAxis{ii},1000.*DensityAnomalyModel{ii});colormap(colorbrew);caxis([-15,15]);freezeColors;hold on;
+% %         plot(Traverse{ii},depth550,'--k','linewidth',3);
+%         imagesc(Traverse{ii},DepthAxis{ii},sign(RadarDepth{ii}),'AlphaData',WiggleAlpha);colormap([0,0,0]);freezeColors;
+% %         colormap(SplitJet);hlay = colorbar; %set(hlay,'YDir','reverse','fontsize',14,'fontweight','bold');
+%         colormap(colorbrew);hlay = colorbar;
+        figure();
+        imagesc(Traverse{ii}./1000,DepthAxis{ii},1000.*DensityAnomalyModel{ii});colormap(colorbrew);caxis([-15,15]);freezeColors;hold on;
+        imagesc(Traverse{ii}./1000,DepthAxis{ii},sign(RadarDepth{ii}),'AlphaData',WiggleAlpha);colormap([0,0,0]);freezeColors;
+        colormap(colorbrew);hlay = colorbar;
+        set(get(hlay,'ylabel'),'String','Deviation from Mean Density [kg/m^{3}]', 'rotation', 270,'Units', 'Normalized', 'Position', [4, 0.5, 0])
+        title('Density Anomaly')
+        xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold')
+        set(gca,'YTick',[0,2.5,5,7.5,10,12.5,15,17.5,20,22.5])
+        
+        figure();
+        hDA1 = subplot(2,1,1);
+        % Plot Mean Average Density Deviation
+%         plot(Traverse{ii},1000.*MeanDensityDeviation{ii},'k','linewidth',3)
+%         title('Mean Average Deviation - Density [kg/m^{3}]')
+        % Plot Surface Density Deviation
+        plot(Traverse{ii}./1000,1000.*SurfaceDensityDeviation{ii},'k','linewidth',3)
+        title('Surface Density - Deviation from Mean (kg/m^{3})')
+        grid on
+        set(gca,'fontsize',14,'fontweight','bold')
+%         set(hDA1,'units','normalized')
+%         hDA1pos = get(hDA1,'Position');
+%         set(hDA1,'position',[hDA1pos(1),hDA1pos(2)+.25, hDA1pos(3), hDA1pos(2)-.25])
+        
+        hDA2 = subplot(2,1,2);
+        % Plot Density Anamoly, Overlay Peak Amplitudes
+        imagesc(Traverse{ii}./1000,DepthAxis{ii},1000.*DensityAnomalyModel{ii});colormap(colorbrew);caxis([-15,15]);freezeColors;hold on;
+        imagesc(Traverse{ii}./1000,DepthAxis{ii},sign(RadarDepth{ii}),'AlphaData',WiggleAlpha);colormap([0,0,0]);freezeColors;
+        colormap(colorbrew);hlay = colorbar;
+%         colormap(SplitJet);hlay = colorbar; %set(hlay,'YDir','reverse','fontsize',14,'fontweight','bold');
+        set(get(hlay,'ylabel'),'String','Deviation from Mean Density (kg/m^{3})', 'rotation', 270,'Units', 'Normalized', 'Position', [4, 0.5, 0])
+        title('Density Anomaly')
+        xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold')
+        set(gca,'YTick',[0,2.5,5,7.5,10,12.5,15,17.5,20,22.5])
+        
+        % Plot Depth-Age Tomography
+        figure();imagesc(Traverse{ii}./1000,DepthAxis{ii},AgeModel{ii});colormap(yet_white);freezeColors;hold on;
+        imagesc(Traverse{ii}./1000,DepthAxis{ii},sign(RadarDepth{ii}),'AlphaData',WiggleAlpha);colormap([0,0,0]);freezeColors;
+        colormap(yet_white);hlay = colorbar; set(hlay,'YDir','reverse','fontsize',14,'fontweight','bold','Ticks',[Ages{ii}]);
+        for kk = 1:size(DepthAge{ii},2)
+        plot(linspace(Traverse{ii}(1)./1000,Traverse{ii}(end)./1000,length(Traverse{ii})),DepthAge{ii}(:,kk),'k','linewidth',3)
+        end
+        set(get(hlay,'ylabel'),'String','Age (a)', 'rotation', 270,'Units', 'Normalized', 'Position', [4, 0.5, 0])
+        set(gca,'YTick',[0,2.5,5,7.5,10,12.5,15,17.5,20,22.5])
+        title('Isochronogram')
+        xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.08, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold')            
+  
+    end
+    %% Image Depth Section
+    for ii = 1:nFiles
+%         figure();imagesc(Traverse{ii},DepthAxis{ii},RadarDepth{ii});
+%         figure();imagesc(Traverse{ii}./1000,DepthAxis{ii},AGCgain(RadarDepth{ii},size(RadarDepth{ii},1)./round(5),2));
+%         colormap(cmapAdapt(RadarDepth{ii},colorbrew));hold on;
+ figure();imagesc(Traverse{ii}./1000,DepositionAxis{ii},AGCgain(RadarDeposition{ii},size(RadarDeposition{ii},1)./round(5),2));
+        colormap(cmapAdapt(RadarDeposition{ii},colorbrew));hold on;
+%         for kk = 1:size(DepthAge{ii},2)
+%             plot(linspace(Traverse{ii}(1)./1000,Traverse{ii}(end)./1000,length(Traverse{ii})),DepthAge{ii}(:,kk),'color',c3,'linewidth',2)
+%         end
+%         for kk = 1:size(DepthAge{ii},2)
+%         plot(Traverse{ii},DepthAge{ii}(:,kk),'k','linewidth',3)
+%         end
+%         title('Core 15 Spur West - Depth Section')
+        title('Core 15 Spur West - Age Section')
+
+        xlabel('Distance (km)')
+%         ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        ylabel('age (a)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold')
+        
+
+        
+        % Plot RadarGram with Isochrones
+%         figure();imagesc(Traverse{ii},DepthAxis{ii},RadarDepth{ii});
+        figure();imagesc(Traverse{ii}./1000,DepthAxis{ii},AGCgain(RadarDepth{ii},size(RadarDepth{ii},1)./round(3.5),2));
+        colormap(cmapAdapt(RadarDepth{ii},colorbrew));hold on;
+        for kk = 1:size(DepthAge{ii},2)
+        plot(linspace(Traverse{ii}(1)./1000,Traverse{ii}(end)./1000,length(Traverse{ii})),DepthAge{ii}(:,kk),'color',c3,'linewidth',2)
+        end
+        
+        % Compare Time to Depth Images
+        compareIx = 7550:11500;
+        compareIy = 165:565;
+        % Salt and Pepper Time Image
+        figure();
+             pcolor(Traverse{ii}(compareIx)./1000,tStack{ii}(compareIy,1),AGCgain(RadarStack{1}(compareIy,compareIx),size(Radar{ii}(:,:),1)./round(7.5),2)); shading interp; axis ij
+        colormap(cmapAdapt(RadarStack{1}(compareIy,compareIx),colorbrew));hold on;
+%         subplot(2,1,1)
+%      imagesc(Traverse{ii}(:)./1000,tStack{ii}(:,1),AGCgain(RadarNMO{8}(:,:),size(Radar{ii}(:,:),1)./round(3.5),2));
+%         colormap(cmapAdapt(Radar{4}(compareIy,compareIx),colorbrew));hold on;
+%         imagesc(Traverse{ii}(compareIx)./1000,tStack{ii}(compareIy,1),AGCgain(RadarNMO{8}(compareIy,compareIx),size(Radar{ii}(compareIy,compareIx),1)./round(3.5),2));
+%         colormap(cmapAdapt(Radar{4}(compareIy,compareIx),colorbrew));hold on;
+%         title('Core 15 Spur West - Time Section')
+        title('Time Section')
+        xlabel('Distance (km)')
+        ylabel('Travel-Time (ns)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold','layer','top')
+                daspect([1 9.5 1])
+
+%         axis square
+%         compareIy = 150:550;
+                compareIy = 150:1000;
+
+        % Bread and Butter Depth Image
+        figure();
+%         subplot(2,1,2)
+%         imagesc(Traverse{ii}(compareIx)./1000,DepositionAxis{ii}(compareIy),AGCgain(RadarDeposition{ii}(compareIy,compareIx),size(RadarDeposition{ii}(compareIy,compareIx),1)./round(3.5),2));
+        pcolor(Traverse{ii}(compareIx)./1000,DepositionAxis{ii}(compareIy),AGCgain(RadarDeposition{ii}(compareIy,compareIx),size(RadarDeposition{ii}(compareIy,compareIx),1)./round(5),2));shading interp, axis ij
+        colormap(cmapAdapt(RadarDeposition{ii}(compareIy,compareIx),colorbrew));hold on;
+                
+%                 for kk = 1:length(isochronePick)
+%                     plot(Traverse{ii}(compareIx)./1000,isochronePick{kk}(compareIx),'k','linewidth',2)
+%                 end
+
+%         imagesc(Traverse{ii}(compareIx)./1000,DepthAxis{ii}(compareIy),AGCgain(RadarDepth{ii}(compareIy,compareIx),size(RadarDepth{ii}(compareIy,compareIx),1)./round(3.5),2));
+%         colormap(cmapAdapt(RadarDepth{ii}(compareIy,compareIx),colorbrew));hold on;
+%         title('Core 15 Spur West - Depth Section')
+%         title('Core 15 Spur West - Age Section')
+
+%         title('Depth Section')
+        title('Age Section')
+        xlabel('Distance (km)')
+%         ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+        ylabel('Age (a)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+
+        set(gca,'fontsize',14,'fontweight','bold')
+%         daspect([1 1 1])
+        daspect([1 2 1])
+
+%         text(.65,-.25,'1000x Vertical Exaggeration','units','normalized','fontsize',10,'fontweight','bold')
+%         axis square
+
+        figure();
+        compareIy = 150:600;
+%         subplot(2,1,2)
+%         imagesc(Traverse{ii}(compareIx)./1000,DepthAxis{ii}(compareIy),AGCgain(RadarDepth{ii}(compareIy,compareIx),size(RadarDepth{ii}(compareIy,compareIx),1)./round(3.5),2));
+%         colormap(cmapAdapt(RadarDepth{ii}(compareIy,compareIx),colorbrew));hold on;
+        pcolor(Traverse{ii}(compareIx)./1000,DepthAxis{ii}(compareIy),AGCgain(RadarDepth{ii}(compareIy,compareIx),size(RadarDepth{ii}(compareIy,compareIx),1)./round(3.5),2)); shading interp; axis ij;
+        colormap(cmapAdapt(RadarDepth{ii}(compareIy,compareIx),colorbrew));hold on;
+%         title('Core 15 Spur West - Depth Section')
+        title('Depth Section')
+        xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.05, 0.5, 0])
+
+        set(gca,'fontsize',14,'fontweight','bold','layer','top')
+        daspect([1 1 1])
+
+        text(.65,-.25,'1000x Vertical Exaggeration','units','normalized','fontsize',10,'fontweight','bold')
+%         axis square
+ 
+        % Plot Depth-Age Tomography
+        figure();pcolor(Traverse{ii}(compareIx)./1000,DepthAxis{ii}(compareIy),bestAgeModel{ii}(compareIy,compareIx));colormap(yet_black);freezeColors;hold on;
+%         imagesc(Traverse{ii},DepthAxis{ii},sign(RadarDepth{ii}),'AlphaData',WiggleAlpha);colormap([0,0,0]);freezeColors;
+        colormap(yet_white); shading interp;axis ij
+        %hlay = colorbar; set(hlay,'YDir','reverse','fontsize',14,'fontweight','bold','Ticks',[5.5:5:20.5],'TickLabels',[2012,2007,2002,1997]);
+%         for kk = 1:size(DepthAge{ii},2)
+%         plot(Traverse{ii}(compareIx)./1000,DepthAge{ii}(compareIx,kk),'k','linewidth',1.5)
+%         end
+          contour(Traverse{ii}(compareIx)./1000,DepthAxis{ii}(compareIy),bestAgeModel{ii}(compareIy,compareIx),7:5:17,'k','linewidth',1.5)
+%         set(get(hlay,'ylabel'),'String','Age (a)', 'rotation', 270,'Units', 'Normalized', 'Position', [4, 0.5, 0])
+%         set(gca,'YTick',[4,6,8,10])
+%         title('Core 15 Spur West - Age-Depth Section')
+                title('Age-Depth Section')
+        xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.08, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold','layer','top') 
+        daspect([1 1 1])
+        text(.65,-.25,'1000x Vertical Exaggeration','units','normalized','fontsize',10,'fontweight','bold')
+        
+        % Age-Travel-Time Model
+        compareIx = 7550:11500;
+        compareIy = 165:565;
+        figure();pcolor(Traverse{ii}(compareIx)./1000,TimeAxis{ii}(compareIy),pseudoAgeModel{ii}(compareIy,compareIx));
+        hold on;shading interp;axis ij;
+        colormap(yet_white);
+        tmpAges = 7:5:17;
+        for kk = 1:length(tmpAges)
+        [~,tmpIx] = min(abs(pseudoAgeModel{ii}(compareIy,compareIx)-tmpAges(kk)));
+        psuedoAgeIx(kk,:) = tmpIx;
+        end
+%         psuedoAgeIx = find(pseudo
+        contour(Traverse{ii}(compareIx)./1000,TimeAxis{ii}(compareIy),pseudoAgeModel{ii}(compareIy,compareIx),7:5:17,'k','linewidth',1.5)
+ 
+        title('Age-Travel-Time Section')
+        xlabel('Distance (km)')
+        ylabel('Travel-Time (ns)','rotation',270, 'Units', 'Normalized', 'Position', [-0.08, 0.5, 0])
+        set(gca,'fontsize',14,'fontweight','bold','layer','top') 
+        daspect([1 8.5 1])
+        
+        % Plot Age-Travel-Time Perturbations
+        tmpResidual = updatePseudoAgeModel{ii}(compareIy,compareIx)-pseudoAgeModel{ii}(compareIy,compareIx);
+        figure();
+        pcolor(Traverse{ii}(compareIx)./1000,TimeAxis{ii}(compareIy),tmpResidual);
+        shading interp; axis ij; colormap(cmapAdapt(tmpResidual,SplitJet));
+        freezeColors;
+        c = colorbar; c.Location = 'northoutside';c.Label.String = 'Age Perturbations (\Delta a)';
+        c.FontSize = 12; c.Label.FontSize = 16;
+         set(gca,'fontsize',14,'fontweight','bold','layer','top') 
+        daspect([1 8.5 1])
+                xlabel('Distance (km)')
+        ylabel('Travel-Time (ns)','rotation',270, 'Units', 'Normalized', 'Position', [-0.08, 0.5, 0])
+        
+                % Plot Recalculated Age-Travel-Time Perturbations
+                compareIy = 150:600;
+        tmpResidual = perturbations(compareIy,compareIx);%updatePseudoAgeModel{ii}(compareIy,compareIx)-pseudoAgeModel{ii}(compareIy,compareIx);
+        figure();
+        pcolor(Traverse{ii}(compareIx)./1000,DepthAxis{ii}(compareIy),tmpResidual);
+        shading interp; axis ij;caxis([-0.5,0.5])% colormap(cmapAdapt(tmpResidual,SplitJet));
+        colormap(SplitJet)
+%         freezeColors;
+        c = colorbar; c.Location = 'northoutside';c.Label.String = 'Age Perturbations (\Delta a)';
+        c.FontSize = 12; c.Label.FontSize = 16;
+         set(gca,'fontsize',14,'fontweight','bold','layer','top') 
+        daspect([1 1 1])
+                xlabel('Distance (km)')
+        ylabel('Depth (m)','rotation',270, 'Units', 'Normalized', 'Position', [-0.08, 0.5, 0])
+                text(.65,-.25,'1000x Vertical Exaggeration','units','normalized','fontsize',10,'fontweight','bold')
+
+    end
+    
+    % Plot Accumulation
+    q = quantile(tmpAccum(:),[.025,0.975]);
+    figure();
+%     subplot(4,1,1)
+    plot(Traverse{ii}./1000,AverageAccumulation{ii},'k','linewidth',2);
+    hold on;
+    plot(Traverse{ii}./1000,AverageAccumulation2{ii},'r','linewidth',2)
+    plot(Traverse{ii}./1000,AverageAccumulation3{ii},'b','linewidth',2)
+    set(gca,'fontsize',10,'fontweight','bold')
+
+    figure();
+    subplot(3,1,1)
+    % Initial Accumulation
+    imagesc(Traverse{ii}./1000,DepthAxis{ii},initAccum,q);colormap(yet_white);
+    set(gca,'fontsize',10,'fontweight','bold','xticklabel',[])
+    
+    subplot(3,1,2)
+    % First Update Accumulation
+    pcolor(Traverse{ii}./1000,DepthAxis{ii},instantDoom);shading interp;colormap(yet_white); axis ij;
+    set(gca,'fontsize',10,'fontweight','bold','layer','top','xticklabel',[]);caxis([q]);
+
+    subplot(3,1,3)
+    % Sencond Update Accumulation
+    pcolor(Traverse{ii}./1000,DepthAxis{ii},tmpAccum);shading interp;colormap(yet_white);axis ij;
+    set(gca,'fontsize',10,'fontweight','bold','layer','top');caxis([q])
+
+
+end
+
+%% Create Figures for Snow Surface Data
+if isSWEDISH
+    % plot Direct Wave Data
+    for ii = 1:nFiles
+        figure();
+        subplot(3,1,1)
+        for dh = 2:nDirectHorizon
+            shadedErrorBarT8([],dhSnowWaterEqv{dh,ii},...
+                sqrt(dhSnowWaterEqvVar{dh,ii}),1,{'Color',[0.5,0,0],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        title('Accumulation [m w.e.]')
+        subplot(3,1,2)
+        for dh = 2:nDirectHorizon
+            shadedErrorBarT8([],dhDensity{dh,ii}.*1000,...
+                sqrt(dhDensityVar{dh,ii}).*1000,1,{'Color',[0,0,.5],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        title('Average Density [kg/m^{3}]')
+        subplot(3,1,3)
+        for dh = 2:nDirectHorizon
+            shadedErrorBarT8([],dhDepth{dh,ii},...
+                sqrt(dhDepthVar{dh,ii}),1,{'Color',[0,0,0],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        title('Depth [m]')
+        set(findobj(gcf,'type','axes'),'FontName','Arial','FontSize',12,...
+            'FontWeight','Bold', 'LineWidth', 1);
+    end
+    % Plot Reflection Data
+    for ii = 1:nFiles
+        figure();
+        subplot(3,1,1)
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(Traverse{ii}./1000,SnowWaterEqv{rh,ii},...
+                sqrt(SnowWaterEqvVar{rh,ii}),1,{'Color',c1,'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        title('Average Annual Accumulation [m w.e. a^{-1}]')
+        subplot(3,1,2)
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(Traverse{ii}./1000,Density{rh,ii}.*1000,...
+                sqrt(DensityVar{rh,ii}).*1000,1,{'Color',[0,0,0],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        title('Average Snow Density [kg/m^{3}]')
+        subplot(3,1,3)
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(Traverse{ii}./1000,Depth{rh,ii},...
+                sqrt(DepthVar{rh,ii}),1,{'Color',c3,'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        title('Snow Depth [m]')
+        xlabel('Distance [km]')
+        set(findobj(gcf,'type','axes'),'FontName','FreeSerif','FontSize',12,...
+            'FontWeight','Bold', 'LineWidth', 1);
+    end
+end
+%% Joint Figure for Snow Surface Data
+if isSWEDISH
+    % plot Direct Wave Data
+    for ii = 1:nFiles
+        distance = Traverse{ii};
+        figure();
+        subplot(3,1,1)
+%         for dh = 2:nDirectHorizon
+%             shadedErrorBarT8(distance,dhDepth{dh,ii},...
+%                 sqrt(dhDepthVar{dh,ii}),1,{'Color',[1,0.81,0],'linewidth',1.5});
+%             hold on;
+%         end
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(distance./1000,Depth{rh,ii},...
+                sqrt(DepthVar{rh,ii}),1,{'Color',[0,0,0],'linewidth',1.5});
+
+%                 sqrt(DepthVar{rh,ii}),1,{'Color',[1,0.81,0],'linewidth',1.5});
+
+            hold on;
+        end
+        freezeColors
+        axis ij
+        axis tight
+        grid on
+        ylim([1.6 2.2])
+        set(gca,'ytick',[1.6,1.8,2.0,2.2])
+        set(gca,'xticklabel',[])
+        title('Snow Depth (m)')
+        subplot(3,1,2)
+        for dh = 2:nDirectHorizon
+            shadedErrorBarT8(distance,dhDensity{dh,ii}.*1000,...
+                sqrt(dhDensityVar{dh,ii}).*1000,1,{'Color',[0,0,0],'linewidth',1.5});
+%                 sqrt(dhDensityVar{dh,ii}).*1000,1,{'Color',[0.5,0,0],'linewidth',1.5});
+            hold on;
+        end
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(distance,Density{rh,ii}.*1000,...
+                sqrt(DensityVar{rh,ii}).*1000,1,{'Color',[0,0,0],'linewidth',1.5});
+%                 sqrt(DensityVar{rh,ii}).*1000,1,{'Color',[0.5,0,0],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis ij
+        axis tight
+        grid on
+        set(gca,'xticklabel',[])
+        set(gca,'ytick',[350,375,400])
+        title('Average Density (kg/m^{3})')
+        subplot(3,1,3)
+%         for dh = 2:nDirectHorizon
+%             shadedErrorBarT8(distance,dhSnowWaterEqv{dh,ii},...
+%                 sqrt(dhSnowWaterEqvVar{dh,ii}),1,{'Color',[0,0,0],'linewidth',1.5});
+%             hold on;
+%         end
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(distance,AverageAccumulation{ii},...
+                sqrt(SnowWaterEqvVar{rh,ii}),1,{'Color',[0,0,0],'linewidth',1.5});            
+%             shadedErrorBarT8(distance,SnowWaterEqv{rh,ii},...
+%                 sqrt(SnowWaterEqvVar{rh,ii}),1,{'Color',[0,0,0],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        set(gca,'ytick',[0.24,0.27,0.3,0.33])
+        title('Average Annual Accumulation (m w.e. a^{-1})')
+        set(gca,'xtick',1000.*[0, 20, 40, 60, 78])
+        set(gca,'xticklabel',[0,20,40,60,78])
+        xlabel('Distance (km)')
+        set(findobj(gcf,'type','axes'),'FontName','FreeSerif','FontSize',12,...
+            'FontWeight','Bold', 'LineWidth', 1);
+    end
+end
+%% Compare Average Accumulation
+if (isPickDepthHorizons || isLoadDepthHorizons) && (isPickAgeHorizons || isLoadIRH)
+        for ii = 1:nFiles
+        distance = Traverse{ii}./1000;
+        figure(); hold on;
+%          shadedErrorBarT8(distance,AverageAccumulation2{ii},...
+%              sqrt(varAccumulation2{ii}),1,{'Color',[0,0,0],'linewidth',1.5});
+%                  freezeColors
+
+         shadedErrorBarT8(distance,AverageAccumulation3{ii},...
+             sqrt(varAccumulation3{ii}),1,{'Color',[0,0,0],'linewidth',3});
+                 freezeColors
+
+                  for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(distance,AverageAccumulation{ii},...
+                sqrt(SnowWaterEqvVar{rh,ii}),1,{'Color',[0.5,0,0],'linewidth',2});
+            alpha(0.5)
+                  end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+%          title('Average Annual Accumulation (m w.e. a^{-1})')
+         title({['\fontsize{14}Average Annual Accumulation'];...
+             ['\fontsize{12}\color[rgb]{0.5 0 0}Jan.2015-Jan.2017 \color[rgb]{0 0 0}Jan.1984-Jan.2017']})
+        set(gca,'xtick',[0, 20, 40, 60, 78])
+        set(gca,'xticklabel',[0,20,40,60,78])
+        set(gca,'fontsize',12,'fontweight','bold')
+        xlabel('Distance (km)')
+        ylabel('(m w.e. a^{-1})')
+        
+        figure();
+        subplot(3,1,1)
+
+        for rh = 1:nReflectionHorizon
+            shadedErrorBarT8(distance,AverageAccumulation{ii},...
+                sqrt(SnowWaterEqvVar{rh,ii}),1,{'Color',[0,0,0],'linewidth',1.5});
+            hold on;
+        end
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        set(gca,'ytick',[0.24,0.27,0.3,0.33])
+        title('Average Annual Accumulation (m w.e. a^{-1})')
+        set(gca,'xtick',1000.*[0, 20, 40, 60, 78])
+        set(gca,'xticklabel',[0,20,40,60,78])
+
+        subplot(3,1,2)
+            shadedErrorBarT8(distance,AverageAccumulation2{ii},...
+                sqrt(varAccumulation2{ii}),1,{'Color',[0,0,0],'linewidth',1.5});            
+            hold on;
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        set(gca,'ytick',[0.24,0.27,0.3,0.33])
+        title('Average Annual Accumulation (m w.e. a^{-1})')
+        set(gca,'xtick',1000.*[0, 20, 40, 60, 78])
+        set(gca,'xticklabel',[0,20,40,60,78])
+        subplot(3,1,3)
+            shadedErrorBarT8(distance,AverageAccumulation{ii},...
+                sqrt(varAccumulation3{ii}),1,{'Color',[0,0,0],'linewidth',1.5});            
+            hold on;
+        freezeColors
+        axis tight
+        axis ij
+        grid on
+        set(gca,'ytick',[0.24,0.27,0.3,0.33])
+        title('Average Annual Accumulation (m w.e. a^{-1})')
+        set(gca,'xtick',1000.*[0, 20, 40, 60, 78])
+        set(gca,'xticklabel',[0,20,40,60,78])
+        xlabel('Distance (km)')
+        set(findobj(gcf,'type','axes'),'FontName','FreeSerif','FontSize',12,...
+            'FontWeight','Bold', 'LineWidth', 1);
+    end
+end

--- a/PickDepthHorizons.m
+++ b/PickDepthHorizons.m
@@ -1,0 +1,39 @@
+%% Pick Depth-Horizons
+% After conversion to depth, some residual between the MxHL
+% Age-Depth model and the radar isochrones exists. Use this program with
+% polarPicker.m to identify isochrones and calculate the modeled misfit.
+% This update is applied to the isochronogram after fx-deconvolution.
+
+% Allocation
+    depthRadar = RadarDepth;
+    
+        % AGC Gain for PolarPicker 
+    for ii = 1:nFiles
+            depthRadar{ii} = AGCgain(depthRadar{ii},350,2);
+    end
+    
+    % Plot Common-offset gathers
+    isPlotDepthImage = 0;
+    if isPlotDepthImage
+        for ii = 1:nFiles
+            for jj = 1:length(RadarStack)
+                figure();
+                    imagesc(depthRadar{jj,ii});colormap(cmapAdapt(depthRadar{jj,ii},colorbrew));
+            end
+        end
+        
+        % Pause to Examine Deposition Depth Image
+        display('Review the Depth Image')
+        display('Press F5 to Continue')
+        display(' ')
+        keyboard
+    end
+    
+    % Pick Isochrones
+    display('Pick Isochrones')
+    display(' ')
+    display('Isochronous Horizons Must be Picked Sequentially in Depth!')
+    display(' ')
+    [~, depthPick] = polarPickerT8(depthRadar);
+    
+    clear('depthRadar','isPlotDepthImage')

--- a/ReCalculateAgeResidual.m
+++ b/ReCalculateAgeResidual.m
@@ -1,0 +1,118 @@
+%% Caclulate Stratigraphic Depth Residual
+% The residual of the picked depth-horizons is measured optionally against 
+% the nearby GreenTrACS firn core.
+% depthPick(21) = [];
+% depthPick(1) = [];
+% Determine Number of Age Horizons
+nZHorizon = size(depthPick,2);
+
+% Calculate Residual
+isoResidual = depthPick;
+agePick = depthPick;%zeros(nZHorizon,nFiles);
+warning('off','MATLAB:mir_warning_changing_try_catch');
+try iceCoreIx;
+catch
+    iceCoreIx = 1:100;
+end
+
+% Cacluate the Age Residual each row of the matrix should have the same age
+for ii = 1:nFiles
+    dZ = mean(diff(DepthAxis{ii}));
+    for jj = 1;% chan (Loop over chan for Mx processing)
+             % Test for Age samples or Index
+            if all(max([depthPick{jj,:,ii}]) > 20) % 20 samples/depth threshold
+                isConvert = 1;
+            else
+                isConvert = 0;
+            end
+        for zh = 1:nZHorizon
+            if isConvert
+            % Convert Samples to Age
+            depthPick{jj,zh,ii} = depthPick{jj,zh,ii}.*dZ;
+            end
+            % Determine Measurement Datum
+            if isGreenTracsFirnCore
+                % depthAge : Depth is the linear Axis!
+                GTCdepthAge = interp1(abs(GTCdepthAge(:,1)-GTCdepthAge(1,1)),GTCdepthAge(:,2),DepthAxis{ii},'pchip');
+                GTCdepthAge = [DepthAxis{ii},GTCdepthAge];
+                % Average Core Location Isochrone Depth as Datum
+                isochroneDepth(zh,ii) = mean(depthPick{jj,zh,ii}(iceCoreIx));
+                [~,datumIx] = min(abs(GTCdepthAge(:,1) - isochroneDepth(zh,ii)));
+            else
+                [~,datumIx] = min(abs(mean(depthPick{jj,zh,ii}(iceCoreIx))-DepositionAxis{ii}));
+            end
+            % Grab the mean updated Age-Depth Model at iceCoreIx
+%             ageDatum(zh,ii) = mean(updateAgeModel{ii}(datumIx,iceCoreIx));
+               tmpIx = sub2ind(size(updateAgeModel{ii}),round(depthPick{jj,zh,ii}./dZ),...
+                   [1:length(depthPick{jj,zh,ii})]');
+            agePick{jj,zh,ii} = updateAgeModel{ii}(tmpIx);
+            % Calculate Misfit -- Subtract Residuals from Model for Update! 
+            datumDepthAge(zh) =  abs(GTCdepthAge(datumIx,2)-GTCdepthAge(1,2));
+            isoResidual{jj,zh,ii} = agePick{jj,zh,ii} - abs(GTCdepthAge(datumIx,2)-GTCdepthAge(1,2));
+        end
+        % Interpolate Perterbations to Depth
+        tmpResidual = [isoResidual{:}];tmpResidual = [zeros(length(tmpResidual),1),tmpResidual];
+        tmpDepthPicks = [depthPick{:}];tmpDepthPicks = [zeros(length(tmpResidual),1),tmpDepthPicks];
+        tmpAxis = DepthAxis{ii};
+        perturbations = zeros(size(updateAgeModel{ii}));
+        tmpAgeModel = perturbations;
+        parfor (kk = 1:length(updateAgeModel{ii}), nWorkers)
+%         for kk = 1:length(updateAgeModel{ii})
+        perturbations(:,kk) = interp1(tmpDepthPicks(kk,:),tmpResidual(kk,:),tmpAxis,'linear','extrap');
+        end
+        % Smooth Perturbations
+        perturbations = imgaussfilt(perturbations,[0.1,50]);
+        for kk = 1:length(updateAgeModel{ii})
+        % Re-Update AgeDepth Model
+        tmpAgeModel(:,kk) = updateAgeModel{ii}(:,kk) - perturbations(:,kk);
+        % Correction to Surface Gradients
+        tmpIx = find(diff(sign(tmpAgeModel(:,kk))),1,'last');
+        if tmpIx > 1
+        tmpIx = (20.*tmpIx) + 1;
+        surfIx = 1:tmpIx;
+        tmpAgeModel(surfIx,kk) = linspace(0,tmpAgeModel(tmpIx,kk),tmpIx);
+        end
+        end
+        bestAgeModel{ii} = tmpAgeModel;
+        clear ('tmpResidual','tmpDepthPicks','tmpAxis','tmpIx','tmpAgeModel')
+        % 1st order Finite Difference 
+        tmpDiffA = diff(bestAgeModel{ii});  % da
+        tmpDiff = diff(DepthMatrix{ii});    % dz
+        dUpdateAgeModel = [tmpDiff(1,:);tmpDiff]; % Colocation
+        % Compute the Integrated Average Accumulation
+        AverageAccumulationMatrix = (DepthMatrix{ii}.*AvgDensityModel{ii})./(bestAgeModel{ii}+eps);
+        % Compute dz/da for instantaneous accumulation
+        testInstant = (dUpdateAgeModel.*DensityModel{ii})./([tmpDiffA(1,:);tmpDiffA]);
+        % Despike Mathy Noise
+        cutoff = quantile(testInstant(:),[.005,.995]);
+        tmpIx = find(testInstant<cutoff(1) | testInstant > cutoff(2));
+        testInstant(tmpIx) = NaN;
+%         testInstant = inpaint_nans(testInstant,0); % Quite Slow
+        testInstant = fillmissing(testInstant,'linear');
+        clear('cutoff','tmpIx')
+        A1 = 2017; % Upper Year Bound
+        % Lower Year Bound A2 = 1984
+        A2 = round(abs(max(datumDepthAge)-(str2num(Year{1})+dayofyear/365)));
+        tmpAccum = testInstant;
+        m = size(bestAgeModel{ii},1);
+        n = size(bestAgeModel{ii},2);
+        reportAccum = zeros(n,1);
+        varAccum = zeros(n,1);
+        for kk = 1:n
+            % Find indicies for Age Range A1 - A2
+            ix = find(abs(bestAgeModel{ii}(:,kk)-(str2num(Year{1})+dayofyear/365)) < A1 ...
+                & abs(bestAgeModel{ii}(:,kk)-(str2num(Year{1})+dayofyear/365)) >= A2);
+            % Pad update to Instantaeous Accumulation Model with intial 
+            tmpAccum(~ismember(1:m,ix),kk) = AverageAccumulation{ii}(kk);% tmpAccum is instantDoom
+            reportAccum(kk) = mean(testInstant(ix,kk));
+            varAccum(kk) = var(testInstant(ix,kk));
+        end
+        reportAccum = nonParametricSmooth(Traverse{ii},reportAccum,Traverse{ii},251);
+        varAccum = nonParametricSmooth(Traverse{ii},varAccum,Traverse{ii},251);
+
+        AverageAccumulation3{ii} = reportAccum;
+        varAccumulation3{ii} = varAccum;
+        clear('reportAccum','varAccum',m,n);
+    end
+    clear ('tmp','tmpA','tmZ','datumIx','isConvert','tmpIx','tmpResidual');%,'isochroneDepth','GTCageDepth',
+end

--- a/TimeToAgeConversion.m
+++ b/TimeToAgeConversion.m
@@ -1,0 +1,42 @@
+%% Time To Stratigraphic Age Conversion
+    % Allocation
+    RadarDeposition = RadarStack;  
+    depositionAgeModel{ii} = cell(1,nFiles);
+    DepositionAxis = cell(1,nFiles);
+    pseudoAgeModel{ii} = cell(1,nFiles);
+
+    for ii = 1:nFiles
+        DepositionAxis{ii} = [linspace(min(AgeModel{ii}(:)),max(AgeModel{ii}(:)),length(AgeModel{ii}(:,1)))]';
+        % Create Age-Time Model
+        pseudoAgeModel{ii} = (StackingVelocityModel{ii}.*(AgeModel{ii})./DepthMatrix{ii}).*(tStack{ii}./2);
+        pseudoAgeModel{ii}(1,:) = 0; % Set NaNs to Zero
+        tmpModel = pseudoAgeModel{ii};
+
+        [m,n] = size(RadarStack{ii});
+        q = 2; % Quantity times the current number of samples
+        RadDeposit = zeros(q.*m,n);
+        RadStack = RadarStack{ii};
+        DepositAxe = DepositionAxis{ii};
+        % ReSample in Age Domain
+        DepositAxe = [linspace(min(DepositAxe),max(DepositAxe),q.*length(DepositAxe))]';
+        DepositionAxis{ii} = DepositAxe;
+        zStak = zStack{ii};
+        tStak = tStack{ii};
+        parfor (kk = 1:size(RadarStack{ii},2), nWorkers)
+%         for kk = 1:size(RadarStack{ii},2)
+%             % [Time, Age] - Array to be resampled
+%             tacurve = [tStak(:,kk),tmpModel(:,kk)];
+%             % Perform Depth Conversion
+%             [RadDeposit(:,kk)] = timeDepthConversion(RadStack(:,kk),tacurve,DepositAxe);
+            % Create the Conversion Axis Time 2 Age (TA)
+            tmpAxTA = interp1(tmpModel(:,kk),tStak(:,kk),DepositAxe,'linear');
+            nanIx = isnan(tmpAxTA);
+            tmpAxTA=tmpAxTA(~nanIx);
+            % Use interp1 Alg Here
+            tmpTrc = interp1(tStak(:,kk),RadStack(:,kk),tmpAxTA,'linear');
+            % Pad Interpolation with Zeros
+            RadDeposit(:,kk) = [tmpTrc;zeros(q.*m - length(tmpTrc),1)];
+        end
+        RadarDeposition{ii} = RadDeposit;
+    end
+    clear('RadDepth','RadStack','DepthAxe','zStak','tStak','tmpModel','RadDeposit','DepositAxe');

--- a/functions/MergeStructs.m
+++ b/functions/MergeStructs.m
@@ -1,0 +1,21 @@
+function [merged_struct] = MergeStructs(struct_a,struct_b)
+%%if one of the structres is empty do not merge
+if isempty(struct_a)
+    merged_struct=struct_b;
+    return
+end
+if isempty(struct_b)
+    merged_struct=struct_a;
+    return
+end
+%%insert struct a
+merged_struct=struct_a;
+%%insert struct b
+size_a=length(merged_struct);
+for j=1:length(struct_b)
+    f = fieldnames(struct_b);
+    for i = 1:length(f)
+        merged_struct(size_a+j).(f{i}) = struct_b.(f{i});
+    end
+end
+end


### PR DESCRIPTION
Depth-domain IRH picking was enabled as polarPicker.m received updates including a throttle for picker control and a debugging. The second round of residual age perturbations are calculated and update the accumulation model. The age to depth conversion and modeling process was developed and given a good round of testing. 